### PR TITLE
✨[FEAT] #8: 유저 검색 기능 구현

### DIFF
--- a/src/book/book.sql.js
+++ b/src/book/book.sql.js
@@ -1,4 +1,4 @@
-export const getBookById = "SELECT * FROM book WHERE book_id = ?";
+export const getBookById = "SELECT * FROM BOOK WHERE book_id = ?";
 
 // 책에 해당하는 카테고리 조회
 export const findCategoryNameByBookId = 

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -28,7 +28,7 @@ export const getUserShorts = async(req, res, next)=> {
     const hasNext = result.length > size;
     if (hasNext) result.pop();
 
-    res.send(response(status.SUCCESS, result, pageInfo(page, size, hasNext)))
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
 
 }
 
@@ -44,7 +44,7 @@ export const getUserLikeShorts = async(req, res, next) => {
     const hasNext = result.length > size;
     if (hasNext) result.pop();
 
-    res.send(response(status.SUCCESS, result, pageInfo(page, size, hasNext)))
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
 }
 
 // 유저가 읽은 책 리스트 조회
@@ -59,7 +59,7 @@ export const getUserBooks = async(req, res, next)=> {
     const hasNext = result.length > size;
     if (hasNext) result.pop();
 
-    res.send(response(status.SUCCESS, result, pageInfo(page, size, hasNext)))
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
 }
 
 // 유저(본인)가 다른 유저 팔로우

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -70,5 +70,14 @@ export const followUser = async(req, res, next)=>{
 
 // 유저 검색
 export const searchUser = async (req, res, next) => {
-    res.send(response(status.SUCCESS, await searchUserByKeyword(req.body, req.query.keyword)))
+
+    const page = parseInt(req.query.page) || 1;
+    const size = parseInt(req.query.size) || 20;
+    const offset = (page - 1) * size;
+
+    const { userSearchResponseDTOList, totalCount } = await searchUserByKeyword(req.body, req.query.keyword, offset, size);
+
+    const hasNext = totalCount > offset + size;
+
+    res.send(response(status.SUCCESS, userSearchResponseDTOList, pageInfo(page, size, hasNext)))
 }

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -75,9 +75,9 @@ export const searchUser = async (req, res, next) => {
     const size = parseInt(req.query.size) || 20;
     const offset = (page - 1) * size;
 
-    const { userSearchResponseDTOList, totalCount } = await searchUserByKeyword(req.body, req.query.keyword, offset, size);
+    const { userSearchResponseDTOList, totalCount, currentSize } = await searchUserByKeyword(req.body, req.query.keyword, offset, size);
 
     const hasNext = totalCount > offset + size;
 
-    res.send(response(status.SUCCESS, userSearchResponseDTOList, pageInfo(page, size, hasNext)))
+    res.send(response(status.SUCCESS, userSearchResponseDTOList, pageInfo(page, currentSize, hasNext)))
 }

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -1,6 +1,13 @@
 import { response } from "../../config/response.js";
 import { status } from "../../config/response.status.js";
-import { findOne, findUserShorts, findUserLikeShorts, findUserBooks, followNewUser } from "./users.service.js";
+import {
+    findOne,
+    findUserShorts,
+    findUserLikeShorts,
+    findUserBooks,
+    followNewUser,
+    searchUserByKeyword
+} from "./users.service.js";
 import { pageInfo } from "../../config/pageInfo.js";
 
 
@@ -59,4 +66,9 @@ export const getUserBooks = async(req, res, next)=> {
 export const followUser = async(req, res, next)=>{
     const result= await  followNewUser (req.body, req.params.userId)
     res.send(response(status.SUCCESS, result))
+}
+
+// 유저 검색
+export const searchUser = async (req, res, next) => {
+    res.send(response(status.SUCCESS, await searchUserByKeyword(req.body, req.query.keyword)))
 }

--- a/src/users/users.dao.js
+++ b/src/users/users.dao.js
@@ -8,7 +8,6 @@ import {
     getUserById,
     getUserLikeShortsIdById,
     getUserShortsById,
-    getImageById,
     addFollowUser,
     findFollowStatus,
     findIfContainsKeywordWithUserId,

--- a/src/users/users.dao.js
+++ b/src/users/users.dao.js
@@ -11,7 +11,6 @@ import {
     addFollowUser,
     findFollowStatus,
     findIfContainsKeywordWithUserId,
-    findAllIfContainsKeyword,
     getEachFollowIdList,
     getMeFollowIdList,
     getMyFollowIdList,
@@ -128,21 +127,6 @@ export const findUserBooksById = async(userId, offset, limit) => {
         throw new BaseError(status.BAD_REQUEST)
     }
 }
-
-// 이미지 아이디로 이미지 찾기 이후에 다른 도메인으로 수정할 필요가 있을듯..?
-// export const findImageById = async(imageId) => {
-//     try{
-//         const conn = await pool.getConnection();
-//         const [image] = await pool.query(getImageById, imageId)
-//
-//         conn.release();
-//         return image[0]
-//     }
-//
-//     catch (err) {
-//         throw new BaseError(status.BAD_REQUEST)
-//     }
-// }
 
 // 유저(본인)가 다른 유저 팔로잉
 export const followUserAdd = async(userId, followingId) => {

--- a/src/users/users.dao.js
+++ b/src/users/users.dao.js
@@ -131,19 +131,19 @@ export const findUserBooksById = async(userId, offset, limit) => {
 }
 
 // 이미지 아이디로 이미지 찾기 이후에 다른 도메인으로 수정할 필요가 있을듯..?
-export const findImageById = async(imageId) => {
-    try{
-        const conn = await pool.getConnection();
-        const [image] = await pool.query(getImageById, imageId)
-
-        conn.release();
-        return image[0]
-    }
-
-    catch (err) {
-        throw new BaseError(status.BAD_REQUEST)
-    }
-}
+// export const findImageById = async(imageId) => {
+//     try{
+//         const conn = await pool.getConnection();
+//         const [image] = await pool.query(getImageById, imageId)
+//
+//         conn.release();
+//         return image[0]
+//     }
+//
+//     catch (err) {
+//         throw new BaseError(status.BAD_REQUEST)
+//     }
+// }
 
 // 유저(본인)가 다른 유저 팔로잉
 export const followUserAdd = async(userId, followingId) => {

--- a/src/users/users.dao.js
+++ b/src/users/users.dao.js
@@ -97,7 +97,7 @@ export const findUserLikeShortsById = async(userId, offset, limit) => {
             userLikeShorts.push(userLikeShort[0])
         }
 
-
+        conn.release();
         return userLikeShorts;
     }
     catch (err) {
@@ -118,6 +118,7 @@ export const findUserBooksById = async(userId, offset, limit) => {
             userBooks.push(userBook[0])
         }
 
+        conn.release();
         return userBooks;
     }
     catch(err){
@@ -131,6 +132,7 @@ export const findImageById = async(imageId) => {
         const conn = await pool.getConnection();
         const [image] = await pool.query(getImageById, imageId)
 
+        conn.release();
         return image[0]
     }
 

--- a/src/users/users.dto.js
+++ b/src/users/users.dto.js
@@ -1,7 +1,6 @@
 // 유저의 마이프로필 페이지에서 유저 정보 조회시 반환값
-import {findImageById} from "./users.dao.js";
 
-export const userInfoResponseDTO = (userData, profileImg, followerNum, followingNum) => {
+export const userInfoResponseDTO = (userData, followerNum, followingNum) => {
     return {
         "userId" : userData.user_id,
         "nickname" : userData.nickname,
@@ -9,14 +8,14 @@ export const userInfoResponseDTO = (userData, profileImg, followerNum, following
         "comment" : userData.comment,
         "followerNum" : followerNum,
         "followingNum" : followingNum,
-        "profileImg" : profileImg }
+        "profileImg" : userData.image_url }
 }
 
 // 유저의 프로필 화면(마이페이지)에 쇼츠 리스트 조회시 반환값
-export const userShortsResponseDTO = (userShorts, shortsImage, shortsBookTitle, shortsBookAuthor) => {
+export const userShortsResponseDTO = (userShorts, shortsBookTitle, shortsBookAuthor) => {
 
     return{   "shortsId" : userShorts.shorts_id,
-        "shortsImage" : shortsImage,
+        "shortsImage" : userShorts.image_url,
         "shortsPhrase" : userShorts.phrase,
         "shortsBookTitle" : shortsBookTitle,
         "shortsBookAuthor" : shortsBookAuthor
@@ -25,10 +24,10 @@ export const userShortsResponseDTO = (userShorts, shortsImage, shortsBookTitle, 
 }
 
 // 유저가 읽은 책 리스트 조회시 반환값
-export const userBookResponseDTO = (userBook, bookImage) => {
+export const userBookResponseDTO = (userBook) => {
 
     return {
-        "bookImage" : bookImage,
+        "bookImage" : userBook.image_url,
         "bookTitle" : userBook.title,
         "bookAuthor" : userBook.author,
         "bookTranslator" : userBook.translator,
@@ -45,10 +44,10 @@ export const userFollowResponseDTO = (userId, followingId) =>{
 }
 
 // 유저 검색시 반환 정보
-export const userSearchResponseDTO =  (userData, profileImg) => {
+export const userSearchResponseDTO =  (userData) => {
     return {
         "userId" : userData.user_id,
-        "profileImg" : profileImg,
+        "profileImg" : userData.image_url,
         "account" : userData.account,
         "nickname" : userData.nickname
     }

--- a/src/users/users.dto.js
+++ b/src/users/users.dto.js
@@ -41,3 +41,12 @@ export const userFollowResponseDTO = (userId, followingId) =>{
         "followingUserId" : followingId
     }
 }
+
+export const userSearchResponseDTO = (userData, profileImg) => {
+    return {
+        "userId" : userData.user_id,
+        "profileImg": profileImg,
+        "account" : userData.account,
+        "nickname" : userData.nickname
+    }
+}

--- a/src/users/users.dto.js
+++ b/src/users/users.dto.js
@@ -1,5 +1,7 @@
 // 유저의 마이프로필 페이지에서 유저 정보 조회시 반환값
-export const userInfoResponseDTO = (userData,  profileImg, followerNum, followingNum) => {
+import {findImageById} from "./users.dao.js";
+
+export const userInfoResponseDTO = (userData, profileImg, followerNum, followingNum) => {
     return {
         "userId" : userData.user_id,
         "nickname" : userData.nickname,
@@ -42,10 +44,11 @@ export const userFollowResponseDTO = (userId, followingId) =>{
     }
 }
 
-export const userSearchResponseDTO = (userData, profileImg) => {
+// 유저 검색시 반환 정보
+export const userSearchResponseDTO =  (userData, profileImg) => {
     return {
         "userId" : userData.user_id,
-        "profileImg": profileImg,
+        "profileImg" : profileImg,
         "account" : userData.account,
         "nickname" : userData.nickname
     }

--- a/src/users/users.route.js
+++ b/src/users/users.route.js
@@ -1,7 +1,7 @@
 import express from "express";
 import asyncHandler from "express-async-handler"
 
-import {getUserInfo, getUserShorts, getUserLikeShorts, getUserBooks, followUser } from "./users.controller.js"
+import {getUserInfo, getUserShorts, getUserLikeShorts, getUserBooks, followUser, searchUser } from "./users.controller.js"
 
 export const userRouter = express.Router({mergeParams:true});
 
@@ -19,3 +19,6 @@ userRouter.get("/my/books", asyncHandler(getUserBooks));
 
 // 다른 유저 팔로잉
 userRouter.post("/:userId/follow", asyncHandler(followUser));
+
+// 유저 검색 기능
+userRouter.get("", asyncHandler(searchUser));

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -6,9 +6,15 @@ import {
     findUserLikeShortsById,
     findUserBooksById,
     findImageById,
-    followUserAdd, findEachFollowerWithKeyword
+    followUserAdd, findEachFollowWithKeyword, findMyFollowWithKeyword, findMeFollowWithKeyword, findUsersWithKeyword
 } from "./users.dao.js";
-import { userBookResponseDTO, userFollowResponseDTO, userInfoResponseDTO, userShortsResponseDTO } from "./users.dto.js";
+import {
+    userBookResponseDTO,
+    userFollowResponseDTO,
+    userInfoResponseDTO,
+    userSearchResponseDTO,
+    userShortsResponseDTO
+} from "./users.dto.js";
 import { findBookById } from "../book/book.dao.js";
 import { status } from "../../config/response.status.js";
 import { BaseError } from "../../config/error.js";
@@ -126,8 +132,74 @@ export const followNewUser = async(body, followUserId) =>{
 export const searchUserByKeyword = async (body, keyword) => {
 
     const userId = body.id
-    const eachFollowUsersList = await findEachFollowerWithKeyword(userId, keyword);
 
-    console.log(eachFollowUsersList)
+    // 키워드에 나 자신의 이름이 섞이는 경우
+    const searchMySelf = await findById(userId);
 
+    // 키워드 + 맞팔인 사람 리스트 (account 기준)
+    const eachFollowUsersListByAccount = await findEachFollowWithKeyword(userId, keyword, 'account');
+
+    // 키워드 + 내가 팔로우하는 사람 리스트 (account 기준)
+    const myFollowUsersListByAccount = await findMyFollowWithKeyword(userId, keyword, 'account');
+
+    // 키워드 + 나를 팔로우하는 사람 리스트 (account 기준)
+    const meFollowUsersListByAccount = await findMeFollowWithKeyword(userId, keyword, 'account');
+
+    // 키워드에 해당하는 모든 사람 리스트 (account 기준)
+    const allUsersListByAccount = await findUsersWithKeyword(userId, keyword, 'account')
+
+    // 키워드로 검색한 최종 유저 목록 (account 기준)
+    const searchFollowUserByAccountList = eachFollowUsersListByAccount.concat(myFollowUsersListByAccount, meFollowUsersListByAccount)
+    searchFollowUserByAccountList.unshift(searchMySelf)
+    const searchUserSet = new Set(searchFollowUserByAccountList.map(user => user.user_id));
+    const uniqueUsers = allUsersListByAccount.filter(user => !searchUserSet.has(user.user_id));
+    const searchUserByAccountList= [...searchFollowUserByAccountList, ...uniqueUsers];
+
+
+    // 키워드 + 맞팔인 사람 리스트 (nickname 기준)
+    const eachFollowUsersListByNickname = await findEachFollowWithKeyword(userId, keyword, 'nickname');
+
+    // 키워드 + 내가 팔로우하는 사람 리스트 (nickname 기준)
+    const myFollowUsersListByNickname = await findMyFollowWithKeyword(userId, keyword, 'nickname');
+
+    // 키워드 + 나를 팔로우하는 사람 리스트 (nickname 기준)
+    const meFollowUsersListByNickname = await findMeFollowWithKeyword(userId, keyword, 'nickname');
+
+    // 키워드에 해당하는 모든 사람 리스트 (nickname 기준)
+    const allUsersListByNickname = await findUsersWithKeyword(userId, keyword, 'nickname')
+
+    // 키워드로 검색한 최종 유저 목록 (nickname 기준)
+    const searchFollowUserByNicknameList = eachFollowUsersListByNickname.concat(myFollowUsersListByNickname, meFollowUsersListByNickname)
+    searchFollowUserByNicknameList.unshift(searchMySelf)
+    const searchUserSet2 = new Set(searchFollowUserByNicknameList.map(user => user.user_id));
+    const uniqueUsers2 = allUsersListByNickname.filter(user => !searchUserSet2.has(user.user_id));
+    const searchUserByNicknameList= [...searchFollowUserByNicknameList, ...uniqueUsers2];
+
+    function removeDuplicates(users) {
+        const seen = new Set();
+        const result = [];
+
+        for (const user of users) {
+            if (!seen.has(user.id)) {
+                seen.add(user.id);
+                result.push(user);
+            }
+        }
+
+        return result;
+    }
+
+    const mergedList = searchUserByAccountList.length >= searchUserByNicknameList.length
+        ? [...searchUserByAccountList, ...searchUserByNicknameList]
+        : [...searchUserByNicknameList, ...searchUserByAccountList];
+
+    const combinedList = Array.from(new Map(mergedList.map(user => [user.user_id, user])).values());
+    const userSearchResponseDTOList = []
+
+    for (const combinedListElement of combinedList) {
+        let profileImg = await findImageById(combinedListElement.image_id)
+        userSearchResponseDTOList.push(userSearchResponseDTO(combinedListElement, profileImg))
+    }
+
+    return userSearchResponseDTOList
 }

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -1,12 +1,16 @@
 import {
     findById,
+    findEachFollowWithKeyword,
     findFollowerNumByUserId,
     findFollowingNumByUserId,
-    findUserShortsById,
-    findUserLikeShortsById,
-    findUserBooksById,
     findImageById,
-    followUserAdd, findEachFollowWithKeyword, findMyFollowWithKeyword, findMeFollowWithKeyword, findUsersWithKeyword
+    findMeFollowWithKeyword,
+    findMyFollowWithKeyword,
+    findUserBooksById,
+    findUserLikeShortsById,
+    findUserShortsById,
+    findUsersWithKeyword,
+    followUserAdd
 } from "./users.dao.js";
 import {
     userBookResponseDTO,
@@ -15,9 +19,9 @@ import {
     userSearchResponseDTO,
     userShortsResponseDTO
 } from "./users.dto.js";
-import { findBookById } from "../book/book.dao.js";
-import { status } from "../../config/response.status.js";
-import { BaseError } from "../../config/error.js";
+import {findBookById} from "../book/book.dao.js";
+import {status} from "../../config/response.status.js";
+import {BaseError} from "../../config/error.js";
 
 // 유저 정보 조회 로직
 export const findOne = async(body) => {
@@ -198,7 +202,7 @@ export const searchUserByKeyword = async (body, keyword) => {
 
     for (const combinedListElement of combinedList) {
         let profileImg = await findImageById(combinedListElement.image_id)
-        userSearchResponseDTOList.push(userSearchResponseDTO(combinedListElement, profileImg))
+        userSearchResponseDTOList.push(userSearchResponseDTO(combinedListElement, profileImg.url))
     }
 
     return userSearchResponseDTOList

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -3,7 +3,6 @@ import {
     findEachFollowWithKeyword,
     findFollowerNumByUserId,
     findFollowingNumByUserId,
-    findImageById,
     findMeFollowWithKeyword, findMeWithKeyword,
     findMyFollowWithKeyword,
     findUserBooksById,
@@ -33,12 +32,12 @@ export const findOne = async(body) => {
         throw new BaseError(status.BAD_REQUEST)
     }
 
-    const profileImg = await findImageById(userData.image_id)
+    // const profileImg = await findImageById(userData.image_id)
 
     const followingNum = await findFollowingNumByUserId(userId);
     const followerNum = await findFollowerNumByUserId(userId);
 
-    return userInfoResponseDTO( userData, profileImg.url, followerNum, followingNum);
+    return userInfoResponseDTO( userData, followerNum, followingNum);
 }
 
 // 유저가 만든 쇼츠 리스트 조회 로직
@@ -57,8 +56,8 @@ export const findUserShorts = async(body, offset, limit) => {
 
     for (const userShort of userShorts) {
         let userShortsBook = await findBookById(userShort.book_id);
-        let shortsImage = await findImageById(userShort.image_id);
-        let result = userShortsResponseDTO(userShort, shortsImage.url, userShortsBook.title, userShortsBook.author);
+        // let shortsImage = await findImageById(userShort.image_id);
+        let result = userShortsResponseDTO(userShort, userShortsBook.title, userShortsBook.author);
         userShortsResponseDTOList.push(result);
     }
 
@@ -80,8 +79,8 @@ export const findUserLikeShorts = async(body, offset, limit) => {
 
     for (const userLikeShort of userLikeShorts) {
         let userLikeShortsBook = await findBookById(userLikeShort.book_id);
-        let shortsImage = await findImageById(userLikeShort.image_id);
-        let result = userShortsResponseDTO(userLikeShort, shortsImage.url, userLikeShortsBook.title, userLikeShortsBook.author);
+        // let shortsImage = await findImageById(userLikeShort.image_id);
+        let result = userShortsResponseDTO(userLikeShort, userLikeShortsBook.title, userLikeShortsBook.author);
         userShortsResponseDTOList.push(result)
     }
 
@@ -102,8 +101,7 @@ export const findUserBooks = async(body, offset, limit) => {
     const userBookResponseDTOList = [];
 
     for (const userBook of userBooks) {
-        let bookImage = await findImageById(userBook.image_id);
-        let result = userBookResponseDTO(userBook, bookImage.url);
+        let result = userBookResponseDTO(userBook);
         userBookResponseDTOList.push(result);
     }
 
@@ -190,9 +188,9 @@ export const searchUserByKeyword = async (body, keyword, offset, size) => {
 
     const userSearchResponseDTOList = []
     for (const paginatedListElement of paginatedList) {
-        let profileImg = await findImageById(paginatedListElement.image_id)
-        userSearchResponseDTOList.push(userSearchResponseDTO(paginatedListElement, profileImg.url))
+        // let profileImg = await findImageById(paginatedListElement.image_id)
+        userSearchResponseDTOList.push(userSearchResponseDTO(paginatedListElement))
     }
 
-    return {userSearchResponseDTOList, totalCount: combinedList.length}
+    return {userSearchResponseDTOList, totalCount: combinedList.length, currentSize: paginatedList.length}
 }

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -6,7 +6,7 @@ import {
     findUserLikeShortsById,
     findUserBooksById,
     findImageById,
-    followUserAdd
+    followUserAdd, findEachFollowerWithKeyword
 } from "./users.dao.js";
 import { userBookResponseDTO, userFollowResponseDTO, userInfoResponseDTO, userShortsResponseDTO } from "./users.dto.js";
 import { findBookById } from "../book/book.dao.js";
@@ -120,4 +120,14 @@ export const followNewUser = async(body, followUserId) =>{
     }
 
     return userFollowResponseDTO(userId, followingId)
+}
+
+// 유저 검색 기능 로직
+export const searchUserByKeyword = async (body, keyword) => {
+
+    const userId = body.id
+    const eachFollowUsersList = await findEachFollowerWithKeyword(userId, keyword);
+
+    console.log(eachFollowUsersList)
+
 }

--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -56,7 +56,6 @@ export const findUserShorts = async(body, offset, limit) => {
 
     for (const userShort of userShorts) {
         let userShortsBook = await findBookById(userShort.book_id);
-        // let shortsImage = await findImageById(userShort.image_id);
         let result = userShortsResponseDTO(userShort, userShortsBook.title, userShortsBook.author);
         userShortsResponseDTOList.push(result);
     }
@@ -79,7 +78,6 @@ export const findUserLikeShorts = async(body, offset, limit) => {
 
     for (const userLikeShort of userLikeShorts) {
         let userLikeShortsBook = await findBookById(userLikeShort.book_id);
-        // let shortsImage = await findImageById(userLikeShort.image_id);
         let result = userShortsResponseDTO(userLikeShort, userLikeShortsBook.title, userLikeShortsBook.author);
         userShortsResponseDTOList.push(result)
     }
@@ -188,7 +186,6 @@ export const searchUserByKeyword = async (body, keyword, offset, size) => {
 
     const userSearchResponseDTOList = []
     for (const paginatedListElement of paginatedList) {
-        // let profileImg = await findImageById(paginatedListElement.image_id)
         userSearchResponseDTOList.push(userSearchResponseDTO(paginatedListElement))
     }
 

--- a/src/users/users.sql.js
+++ b/src/users/users.sql.js
@@ -10,8 +10,6 @@ export const getUserLikeShortsIdById = "SELECT shorts_id FROM LIKE_SHORTS WHERE 
 
 export const getUserReadBooksIdById = "SELECT book_id FROM USER_BOOK WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
 
-//export const getImageById = "SELECT * FROM IMAGE WHERE image_id = ?";
-
 export const addFollowUser = "INSERT INTO FOLLOW(follower, user_id) VALUES(?, ?)";
 
 export const findFollowStatus = "SELECT * FROM FOLLOW WHERE follower = ? AND user_id = ?";

--- a/src/users/users.sql.js
+++ b/src/users/users.sql.js
@@ -16,5 +16,6 @@ export const addFollowUser = "INSERT INTO follow(follower, user_id) VALUES(?, ?)
 
 export const findFollowStatus = "SELECT * FROM follow WHERE follower = ? AND user_id = ?";
 
-export const findIfContainsKeyword = `SELECT * FROM users WHERE user_id = ? AND (account LIKE CONCAT('%', ?, '%')OR nickname LIKE CONCAT('%', ?, '%'));`
+export const findIfContainsKeywordWithUserId = `SELECT * FROM users WHERE user_id = ? AND ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
 
+export const findAllIfContainsKeyword =  `SELECT * FROM users WHERE ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;

--- a/src/users/users.sql.js
+++ b/src/users/users.sql.js
@@ -15,3 +15,6 @@ export const getImageById = "SELECT * FROM image WHERE image_id = ?";
 export const addFollowUser = "INSERT INTO follow(follower, user_id) VALUES(?, ?)";
 
 export const findFollowStatus = "SELECT * FROM follow WHERE follower = ? AND user_id = ?";
+
+export const findIfContainsKeyword = `SELECT * FROM users WHERE user_id = ? AND (account LIKE CONCAT('%', ?, '%')OR nickname LIKE CONCAT('%', ?, '%'));`
+

--- a/src/users/users.sql.js
+++ b/src/users/users.sql.js
@@ -1,24 +1,24 @@
-export const getUserById = "SELECT * FROM users WHERE user_id = ?";
+export const getUserById = "SELECT * FROM USERS WHERE user_id = ?";
 
-export const getUserFollowings = "SELECT * FROM follow WHERE follower = ?";
+export const getUserFollowings = "SELECT * FROM FOLLOW WHERE follower = ?";
 
-export const getUserFollowers = "SELECT * FROM follow WHERE user_id = ?";
+export const getUserFollowers = "SELECT * FROM FOLLOW WHERE user_id = ?";
 
-export const getUserShortsById = "SELECT * FROM shorts WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
+export const getUserShortsById = "SELECT * FROM SHORTS WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
 
-export const getUserLikeShortsIdById = "SELECT shorts_id FROM like_shorts WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
+export const getUserLikeShortsIdById = "SELECT shorts_id FROM LIKE_SHORTS WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
 
-export const getUserReadBooksIdById = "SELECT book_id FROM user_book WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
+export const getUserReadBooksIdById = "SELECT book_id FROM USER_BOOK WHERE user_id = ? ORDER BY CREATED_AT DESC LIMIT ? OFFSET ?";
 
-export const getImageById = "SELECT * FROM image WHERE image_id = ?";
+//export const getImageById = "SELECT * FROM IMAGE WHERE image_id = ?";
 
-export const addFollowUser = "INSERT INTO follow(follower, user_id) VALUES(?, ?)";
+export const addFollowUser = "INSERT INTO FOLLOW(follower, user_id) VALUES(?, ?)";
 
-export const findFollowStatus = "SELECT * FROM follow WHERE follower = ? AND user_id = ?";
+export const findFollowStatus = "SELECT * FROM FOLLOW WHERE follower = ? AND user_id = ?";
 
-export const findIfContainsKeywordWithUserId = `SELECT * FROM users WHERE user_id = ? AND ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
+export const findIfContainsKeywordWithUserId = `SELECT * FROM USERS WHERE user_id = ? AND ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
 
-export const findAllIfContainsKeyword =  `SELECT * FROM users WHERE ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
+export const findAllIfContainsKeyword =  `SELECT * FROM USERS WHERE ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
 
 export const getEachFollowIdList = `SELECT follower FROM FOLLOW WHERE user_id = ? AND follower IN ( SELECT user_id FROM FOLLOW WHERE follower = ?);`
 
@@ -28,8 +28,8 @@ export const getMyFollowIdList = `SELECT user_id FROM FOLLOW WHERE follower = ? 
 
 export const findAllIfContainsKeywordOrdered = `
   SELECT u.*, COUNT(f.follower) AS follower_count
-  FROM users u
-  LEFT JOIN follow f ON u.user_id = f.user_id
+  FROM USERS u
+  LEFT JOIN FOLLOW f ON u.user_id = f.user_id
   WHERE (CASE WHEN ? = 'account' THEN u.account ELSE u.nickname END) LIKE CONCAT('%', ?, '%')
   GROUP BY u.user_id
   ORDER BY follower_count DESC;

--- a/src/users/users.sql.js
+++ b/src/users/users.sql.js
@@ -19,3 +19,18 @@ export const findFollowStatus = "SELECT * FROM follow WHERE follower = ? AND use
 export const findIfContainsKeywordWithUserId = `SELECT * FROM users WHERE user_id = ? AND ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
 
 export const findAllIfContainsKeyword =  `SELECT * FROM users WHERE ( (CASE WHEN ? = 'account' THEN account ELSE nickname END) LIKE CONCAT('%', ?, '%') )`;
+
+export const getEachFollowIdList = `SELECT follower FROM FOLLOW WHERE user_id = ? AND follower IN ( SELECT user_id FROM FOLLOW WHERE follower = ?);`
+
+export const getMeFollowIdList = `SELECT follower FROM FOLLOW WHERE user_id = ? AND follower NOT IN ( SELECT user_id FROM FOLLOW WHERE follower = ?);`
+
+export const getMyFollowIdList = `SELECT user_id FROM FOLLOW WHERE follower = ? AND user_id NOT IN ( SELECT follower FROM FOLLOW WHERE user_id = ?);`
+
+export const findAllIfContainsKeywordOrdered = `
+  SELECT u.*, COUNT(f.follower) AS follower_count
+  FROM users u
+  LEFT JOIN follow f ON u.user_id = f.user_id
+  WHERE (CASE WHEN ? = 'account' THEN u.account ELSE u.nickname END) LIKE CONCAT('%', ?, '%')
+  GROUP BY u.user_id
+  ORDER BY follower_count DESC;
+`;


### PR DESCRIPTION
## 📝 작업 내용

키워드를 입력해 해당 키워드를 포함한 @아이디, 닉네임을 가진 유저를 찾는 기능입니다.

키워드는 쿼리스트링으로 받고, 검색을 시도하는 유저의 정보를 가지고 요청을 보냅니다.

요청을 받으면 몇가지 검색 우선순위를  사용자들을 찾아냅니다.

우선 두가지 경우로 나눕니다.

@아이디가 키워드에 포함된 경우:
1. 맞팔한 사람
2. 내가 팔로우한 사람
3. 나를 팔로우하는 사람
4. 이를 제외한 다른 계정들

닉네임이 키워드에 포함된 경우:
1. 맞팔한 사람
2. 내가 팔로우한 사람
3. 나를 팔로우하는 사람
4. 이를 제외한 다른 계정들

이 두 리스트를 만들고 두 리스트를 합칠때 길이가 더 긴것을 앞으로 두어 먼저 나오게 만듭니다. 
두 리스트가 합쳐질때 중복되는 정보들은 제거 해줍니다.

<img width="866" alt="image" src="https://github.com/user-attachments/assets/66a71ac4-7895-429f-85b7-ecc78e7a671e">


요청결과:

![image](https://github.com/user-attachments/assets/3ca9bb04-0d80-4ccd-b45c-27bfd7f1834e)

## 💬 리뷰 요구사항(선택)

1. users.service.js 에서 보시면 searchUserByKeyword가 유저 검색 부분 서비스 로직인데, @아이디, 닉네임 리스트 두가지를 따로 만들다 보니 코드가 좀 복잡해진 것 같습니다. 지금은 괜찮지만, 검색해서 나오는 양이 많아지면 컨트롤 해줘야 할 것 같습니다. -> 페이징이 잘 도입된다면 괜찮을 것 같기도 합니다. 좋은 방법 있으면 얘기해주세요!!

2. 지금 페이징 처리 부분은 잘 안되어있는데 이 부분을 어떻게 할지 감이 안잡힙니다... 의견이 있다면 말씀해주시면 감사하겠습니다! 둘이 합친 리스트에서 페이징 처리를 진행해야 할지, 아니면 각 리스트를 만들때 페이징 처리를 해서 일부만 가져올지, 가져온다면 몇개씩 가져올지, 이런게 좀 논의 해봐야 할 것 같습니다.

3. 지금 1,2,3의 우선순위 말고 4의 키워드를 포함하는 모든 유저가 그냥 일반 조회로 나오게 만들었는데, 여기서 팔로워가 많은 순 정렬해서 나오게 하는건 어떻게 생각하시나요?? 뭔가 사람들이 유명인을 닉네임으로 검색할때 그 닉네임과 중복된 다른 사람이 위에 많이 나와 그 사람을 검색 못하는 경우가 생길 것 같았습니다. 팔로워가 많은 유명인을 위로 나타나게 하는게 좋을지가 궁금하네요... 그대로 둘지, 아니면 방식을 좀 바꿀지 고민입니다!!

