### PR TITLE
✨[FEAT] #28: 전역 에러 핸들링 상황 테스트 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,12 @@ app.use((err, req, res, next) => {
     res.locals.message = err.message;
     // 개발환경이면 에러를 출력하고 아니면 출력하지 않기
     res.locals.error = process.env.NODE_ENV !== 'production' ? err : {};
-    res.status(err.data.status || status.INTERNAL_SERVER_ERROR).send(response(err.data));
+
+    if (err instanceof BaseError) {
+        return res.status(err.data.status).send(response(err.data));
+    } else {
+        return res.send(response(status.INTERNAL_SERVER_ERROR));
+    }
 });
 
 app.listen(app.get('port'), () => {

--- a/src/shorts/shorts.controller.js
+++ b/src/shorts/shorts.controller.js
@@ -36,9 +36,6 @@ export const searchShorts = async (req, res, next) => {
 };
 
 export const createShorts = async (req, res, next) => {
-    console.log(req.file.location);
-    console.log(req.body);
-
     const book = bookInfoDto(req.body);
 
     if(req.file === undefined) {

--- a/src/shorts/shorts.controller.js
+++ b/src/shorts/shorts.controller.js
@@ -36,24 +36,21 @@ export const searchShorts = async (req, res, next) => {
 };
 
 export const createShorts = async (req, res, next) => {
-    imgUploader.single('image')(req, res, async (err) => {
-        if (err) {
-            return next(new BaseError(status.BAD_REQUEST));
-        }
+    console.log(req.file.location);
+    console.log(req.body);
 
-        const book = bookInfoDto(req.body);
+    const book = bookInfoDto(req.body);
 
-        if(req.file === undefined || req.file.location === undefined) {
-            throw new BaseError(status.BAD_REQUEST);
-        }
-        const shorts = shortsInfoDto(req.body, req.file.location);
+    if(req.file === undefined) {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
+    }
+    const shorts = shortsInfoDto(req.body, req.file.location);
 
-        const shortsId = await service.createShorts(book, shorts, req.body.category);
+    const shortsId = await service.createShorts(book, shorts, req.body.category);
 
-        if(shortsId === undefined) {
-            return next(new BaseError(status.INTERNAL_SERVER_ERROR));
-        }
+    if(shortsId === undefined) {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
+    }
 
-        res.send(response(status.CREATED));
-    });
+    res.send(response(status.CREATED));
 }

--- a/src/shorts/shorts.route.js
+++ b/src/shorts/shorts.route.js
@@ -1,10 +1,13 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import { createShorts, getShortsDetail, searchShorts } from './shorts.controller.js';
+import imgUploader from '../../config/s3.manager.js';
 
 export const shortsRouter = express.Router({mergeParams:true});
 
 shortsRouter.get('/:shortsId', asyncHandler(getShortsDetail));
 shortsRouter.get('', asyncHandler(searchShorts));
 
-shortsRouter.post('', asyncHandler(createShorts));
+shortsRouter.post('', imgUploader.single('image'), (req, res, next) => {
+    next(); // 다음 미들웨어로 넘어가기
+}, asyncHandler(createShorts));

--- a/src/shorts/shorts.service.js
+++ b/src/shorts/shorts.service.js
@@ -156,7 +156,6 @@ export const createShorts = async (book, shorts, category) => {
     
     // book_id 값이 존재하지 않을 경우 책 정보 생성
     if(bookId === undefined) {
-        console.log('category: ', category);
         const categoryId = await getCategoryIdByName(category);
         if(categoryId === undefined) {
             throw new BaseError(status.CATEGORY_NOT_FOUND);

--- a/src/test/test.controllers.js
+++ b/src/test/test.controllers.js
@@ -2,9 +2,10 @@ import { status } from "../../config/response.status.js";
 import { response } from "../../config/response.js";
 import { pageInfo } from "../../config/pageInfo.js";
 import { getErrorTest } from "./test.service.js";
+import { BaseError } from "../../config/error.js";
 
 export const getTest = (req, res, next) => {
-    return res.send(response(status.SUCCESS));
+    res.send(response(status.SUCCESS));
 }
 
 export const getDataTest = (req, res, next) => {
@@ -15,9 +16,20 @@ export const getDataTest = (req, res, next) => {
 export const paginationTest = (req, res, next) => {
     const data = "data";
     const pagination = pageInfo(1, 10, true); // 순서대로 page, size, hasNext
-    return res.send(response(status.SUCCESS, data, pagination));
+    res.send(response(status.SUCCESS, data, pagination));
+}
+
+export const imageTest = async (req, res, next) => {
+    console.log('req: ', req);
+    console.log('res: ', res);
+    console.log('next:', next);
+    res.send(response(status.CREATED, req.file.location));
 }
 
 export const errorTest = async (req, res, next) => {
-    res.send(response(status.SUCCESS, await getErrorTest(req.body)));
+    if(req.query.condition === "controller") {
+        throw new BaseError(status.MEMBER_NOT_FOUND);
+    }
+
+    res.send(response(status.SUCCESS, await getErrorTest(req.query.condition)));
 }

--- a/src/test/test.controllers.js
+++ b/src/test/test.controllers.js
@@ -20,9 +20,6 @@ export const paginationTest = (req, res, next) => {
 }
 
 export const imageTest = async (req, res, next) => {
-    console.log('req: ', req);
-    console.log('res: ', res);
-    console.log('next:', next);
     res.send(response(status.CREATED, req.file.location));
 }
 

--- a/src/test/test.dao.js
+++ b/src/test/test.dao.js
@@ -1,0 +1,10 @@
+import { BaseError } from "../../config/error.js";
+import { status } from "../../config/response.status.js";
+
+export const daoErrorTest = async (condition) => {
+    if (condition === "dao") {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
+    }
+
+    return "PASS";
+}

--- a/src/test/test.route.js
+++ b/src/test/test.route.js
@@ -1,18 +1,17 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { getDataTest, getTest, paginationTest } from './test.controllers.js';
-import { getErrorTest } from './test.service.js';
+import { errorTest, getDataTest, getTest, imageTest, paginationTest } from './test.controllers.js';
 import imgUploader from '../../config/s3.manager.js';
+import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
-import { response } from '../../config/response.js';
 
 export const testRouter = express.Router();
 
 testRouter.get('/', asyncHandler(getTest));
 testRouter.get('/data', asyncHandler(getDataTest));
 testRouter.get('/pagination', asyncHandler(paginationTest));
-testRouter.get('/error', asyncHandler(getErrorTest));
+testRouter.get('/error', asyncHandler(errorTest));
 
-testRouter.post('/image', imgUploader.single('image'), (req, res) => {
-    res.send(response(status.CREATED, req.file.location));
-});
+testRouter.post('/image', imgUploader.single('image'), (req, res, next) => {
+    next(); // 다음 미들웨어로 넘어가기
+}, asyncHandler(imageTest));

--- a/src/test/test.service.js
+++ b/src/test/test.service.js
@@ -1,8 +1,11 @@
 import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
+import { daoErrorTest } from "./test.dao.js";
 
-export const getErrorTest = async (body) => {
-    if (true) throw new BaseError(status.BAD_REQUEST);
+export const getErrorTest = async (condition) => {
+    if (condition === "service") {
+        throw new BaseError(status.CATEGORY_NOT_FOUND);
+    }
 
-    return "ERROR TEST";
+    return await daoErrorTest(condition);
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #28 

## 📝 작업 내용
- 기존 쇼츠 생성 부분쪽 에러들을 전역 에러 핸들링이 잡지 못하는 상황이었는데 해결했습니다!!
- 예상했던대로(?) 이미지 업로드 관련 미들웨어 내에서 발생하는 에러를 잡지 못 하는 상황이었고 이를 다음 미들웨어 (컨트롤러)로 넘겨서 구현되도록 수정하였더니 에러 코드가 잘 반환되는 것을 확인했습니다.
- 앱 내의 에러들은 INTERNAL_SERVER_ERROR가 반환되도록 기능 추가하였습니다.

### 📸 스크린샷 (선택)
<img width="1552" alt="스크린샷 2024-07-30 오전 1 57 48" src="https://github.com/user-attachments/assets/36fd2827-23f0-4b11-b8d0-3598a4ebef17">

## 💬 리뷰 요구사항(선택)
