### PR TITLE
🐛 [BUG] #19: 쇼츠 상세 조회 API 에러 처리 추가

### DIFF
--- a/src/shorts/shorts.detail.dao.js
+++ b/src/shorts/shorts.detail.dao.js
@@ -27,7 +27,7 @@ export const getShortsDetailToShortsId = async (shortsId, userId=null) => {
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -56,7 +56,7 @@ export const getShortsDetailToCategory = async (shortsId, category, size, offset
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -84,7 +84,7 @@ export const getShortsDetailToBook = async (shortsId, bookId, size, offset, user
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -101,7 +101,7 @@ export const countShortsDetailToBook = async (bookId) => {
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -129,7 +129,7 @@ export const getShortsDetailToCategoryExcludeBook = async (category, bookId, siz
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -158,7 +158,7 @@ export const getShortsDetailToUser = async (shortsId, userId, size, offset, myId
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -187,7 +187,7 @@ export const getShortsDetailToUserLike = async (shortsId, userId, size, offset, 
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };
@@ -196,11 +196,16 @@ export const getShortsDetailToCategoryExcludeKeyword = async (category, keywordS
     try {
         const conn = await pool.getConnection();
 
-        // 플레이스홀더 생성
-        const placeholders = keywordShorts.map(() => '?').join(',');
-        const query = sql.getShortsDetailByCategoryExcludeKeyword.replace('<<placeholder>>', placeholders);
+        // 키워드 값에 따라 placeholder를 생성하여 쿼리를 생성
+        let shorts;
+        if(keywordShorts.length === 0) {
+            [shorts] = await conn.query(sql.getShortsDetailByCategory, [category, -1, size, offset]);
+        } else {
+            const placeholders = keywordShorts.map(() => '?').join(',');
+            const query = sql.getShortsDetailByCategoryExcludeKeyword.replace('<<placeholder>>', placeholders);
 
-        const [shorts] = await conn.query(query, [category, ...keywordShorts, size, offset]);
+            [shorts] = await conn.query(query, [category, ...keywordShorts, size, offset]);
+        }
 
         if(userId != null) {
             for(const short of shorts) {
@@ -221,7 +226,7 @@ export const getShortsDetailToCategoryExcludeKeyword = async (category, keywordS
         if(err instanceof BaseError) {
             throw err;
         } else {
-            throw new BaseError(status.PARAMETER_IS_WRONG);
+            throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
     }
 };

--- a/src/shorts/shorts.detail.sql.js
+++ b/src/shorts/shorts.detail.sql.js
@@ -1,13 +1,11 @@
 // 쇼츠 ID에 해당하는 쇼츠 상세 정보를 가져오는 쿼리
 export const getShortsDetailById =
 `SELECT
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     likes.like_count, comments.comment_count, s.book_id
 FROM SHORTS s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count
     FROM LIKE_SHORTS
@@ -31,7 +29,7 @@ WITH followed_users AS (
 
 -- 2. shorts와 해당 shorts의 좋아요 수, 댓글 수, 팔로워 수를 조인하는 CTE
 shorts_with_followers AS (
-    SELECT s.shorts_id, s.user_id, s.book_id, s.image_id,
+    SELECT s.shorts_id, s.user_id, s.book_id, s.image_url,
         s.phrase, s.title, s.content, s.tag,
         COALESCE(likes.like_count, 0) AS like_count, 
         COALESCE(comments.comment_count, 0) AS comment_count,
@@ -61,15 +59,13 @@ shorts_with_followers AS (
 
 -- 3. 최종 결과를 가져오는 쿼리
 SELECT
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     s.like_count, s.comment_count, s.book_id
 FROM shorts_with_followers s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
 WHERE s.shorts_id != ?
-GROUP BY s.shorts_id, u.user_id, i.url, si.url
+GROUP BY s.shorts_id, u.user_id
 ORDER BY s.follower_count DESC, s.like_count DESC
 LIMIT ? OFFSET ?;`;
 
@@ -84,7 +80,7 @@ WITH followed_users AS (
 
 -- 2. shorts와 해당 shorts의 좋아요 수, 댓글 수, 팔로워 수를 조인하는 CTE
 shorts_with_followers AS (
-    SELECT s.shorts_id, s.user_id, s.book_id, s.image_id,
+    SELECT s.shorts_id, s.user_id, s.book_id, s.image_url,
         s.phrase, s.title, s.content, s.tag,
         COALESCE(likes.like_count, 0) AS like_count, 
         COALESCE(comments.comment_count, 0) AS comment_count,
@@ -114,15 +110,13 @@ shorts_with_followers AS (
 
 -- 3. 최종 결과를 가져오는 쿼리
 SELECT
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     s.like_count, s.comment_count, s.book_id
 FROM shorts_with_followers s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
 WHERE s.shorts_id NOT IN (<<placeholder>>)
-GROUP BY s.shorts_id, u.user_id, i.url, si.url
+GROUP BY s.shorts_id, u.user_id
 ORDER BY s.follower_count DESC, s.like_count DESC
 LIMIT ? OFFSET ?;`;
 
@@ -137,7 +131,7 @@ WITH followed_users AS (
 
 -- 2. shorts와 해당 shorts의 좋아요 수, 댓글 수, 팔로워 수를 조인하는 CTE
 shorts_with_followers AS (
-    SELECT s.shorts_id, s.user_id, s.book_id, s.image_id,
+    SELECT s.shorts_id, s.user_id, s.book_id, s.image_url,
         s.phrase, s.title, s.content, s.tag,
         COALESCE(likes.like_count, 0) AS like_count, 
         COALESCE(comments.comment_count, 0) AS comment_count,
@@ -167,14 +161,12 @@ shorts_with_followers AS (
 
 -- 3. 최종 결과를 가져오는 쿼리
 SELECT
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     s.like_count, s.comment_count, s.book_id
 FROM shorts_with_followers s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
-GROUP BY s.shorts_id, u.user_id, i.url, si.url
+GROUP BY s.shorts_id, u.user_id
 ORDER BY s.follower_count DESC, s.like_count DESC
 LIMIT ? OFFSET ?;`;
 
@@ -189,7 +181,7 @@ WITH followed_users AS (
 
 -- 2. shorts와 해당 shorts의 좋아요 수, 댓글 수, 팔로워 수를 조인하는 CTE
 shorts_with_followers AS (
-    SELECT s.shorts_id, s.user_id, s.book_id, s.image_id,
+    SELECT s.shorts_id, s.user_id, s.book_id, s.image_url,
         s.phrase, s.title, s.content, s.tag,
         COALESCE(likes.like_count, 0) AS like_count, 
         COALESCE(comments.comment_count, 0) AS comment_count,
@@ -211,37 +203,33 @@ shorts_with_followers AS (
         s.shorts_id IN (
             SELECT s.shorts_id
             FROM SHORTS s
-            JOIN book b ON s.book_id = b.book_id
+            JOIN BOOK b ON s.book_id = b.book_id
             WHERE b.book_id = ?
         )
 )
 
 -- 3. 최종 결과를 가져오는 쿼리
 SELECT
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     s.like_count, s.comment_count, s.book_id
 FROM shorts_with_followers s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
 WHERE s.shorts_id != ?
-GROUP BY s.shorts_id, u.user_id, i.url, si.url
+GROUP BY s.shorts_id, u.user_id
 ORDER BY s.follower_count DESC, s.like_count DESC
 LIMIT ? OFFSET ?;`;
 
 // 사용자가 작성한 쇼츠 상세 정보를 가져오는 쿼리
 export const getShortsDetailByUser =
 `SELECT 
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     COALESCE(likes.like_count, 0) AS like_count, 
     COALESCE(comments.comment_count, 0) AS comment_count,
     s.book_id
 FROM SHORTS s
 JOIN USERS u ON s.user_id = u.user_id
-JOIN IMAGE i ON u.image_id = i.image_id
-JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count
     FROM LIKE_SHORTS
@@ -253,23 +241,21 @@ LEFT JOIN (
     GROUP BY shorts_id
 ) comments ON s.shorts_id = comments.shorts_id
 WHERE s.user_id = ? AND s.created_at <= (SELECT created_at FROM SHORTS WHERE shorts_id = ?)
-GROUP BY s.shorts_id, u.user_id, i.url, si.url
+GROUP BY s.shorts_id, u.user_id
 ORDER BY s.created_at DESC
 LIMIT ? OFFSET ?;`;
 
 // 사용자가 좋아요한 쇼츠 상세 정보를 가져오는 쿼리
 export const getShortsDetailByUserLike =
 `SELECT 
-    s.user_id, u.account, i.url AS profile_img,
-    si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    s.user_id, u.account, u.image_url AS profile_img,
+    s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     COALESCE(likes.like_count, 0) AS like_count, 
     COALESCE(comments.comment_count, 0) AS comment_count,
     s.book_id
 FROM SHORTS s
 INNER JOIN LIKE_SHORTS ls ON s.shorts_id = ls.shorts_id AND ls.user_id = ?
 LEFT JOIN USERS u ON s.user_id = u.user_id
-LEFT JOIN IMAGE i ON u.image_id = i.image_id
-LEFT JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count
     FROM LIKE_SHORTS
@@ -281,6 +267,6 @@ LEFT JOIN (
     GROUP BY shorts_id
 ) comments ON s.shorts_id = comments.shorts_id
 WHERE ls.created_at <= (SELECT created_at FROM LIKE_SHORTS WHERE user_id = ? AND shorts_id = ?)
-GROUP BY s.shorts_id, u.user_id, i.url, si.url, ls.created_at
+GROUP BY s.shorts_id, u.user_id, ls.created_at
 ORDER BY ls.created_at DESC
 LIMIT ? OFFSET ?;`;

--- a/src/shorts/shorts.sql.js
+++ b/src/shorts/shorts.sql.js
@@ -10,16 +10,14 @@ export const getShortsById = "SELECT * FROM shorts WHERE shorts_id = ?";
 // 책 제목에서 키워드로 쇼츠 검색
 export const getShortsByTitleKeyword = 
 `SELECT 
-    u.user_id, u.account, i.url AS profile_img,
-    s.shorts_id, si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    u.user_id, u.account, u.image_url AS profile_img,
+    s.shorts_id, s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     b.book_id, b.title AS book_title, b.author, b.translator, c.name AS category,
     COALESCE(likes.like_count, 0) AS like_count, 
     COALESCE(comments.comment_count, 0) AS comment_count
 FROM SHORTS s
 LEFT JOIN USERS u ON s.user_id = u.user_id
 LEFT JOIN BOOK b ON s.book_id = b.book_id
-LEFT JOIN IMAGE i ON u.image_id = i.image_id
-LEFT JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN CATEGORY c ON b.category_id = c.category_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count
@@ -37,16 +35,14 @@ ORDER BY s.created_at DESC;`;
 // 저자에서 키워드로 쇼츠 검색
 export const getShortsByAuthorKeyword =
 `SELECT 
-    u.user_id, u.account, i.url AS profile_img,
-    s.shorts_id, si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    u.user_id, u.account, u.image_url AS profile_img,
+    s.shorts_id, s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     b.book_id, b.title AS book_title, b.author, b.translator, c.name AS category,
     COALESCE(likes.like_count, 0) AS like_count, 
     COALESCE(comments.comment_count, 0) AS comment_count
 FROM SHORTS s
 LEFT JOIN USERS u ON s.user_id = u.user_id
 LEFT JOIN BOOK b ON s.book_id = b.book_id
-LEFT JOIN IMAGE i ON u.image_id = i.image_id
-LEFT JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN CATEGORY c ON b.category_id = c.category_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count
@@ -64,16 +60,14 @@ ORDER BY s.created_at DESC;`;
 // 태그에서 키워드로 쇼츠 검색
 export const getShortsByTagKeyword =
 `SELECT 
-    u.user_id, u.account, i.url AS profile_img,
-    s.shorts_id, si.url AS shorts_img, s.phrase, s.title, s.content, s.tag,
+    u.user_id, u.account, u.image_url AS profile_img,
+    s.shorts_id, s.image_url AS shorts_img, s.phrase, s.title, s.content, s.tag,
     b.book_id, b.title AS book_title, b.author, b.translator, c.name AS category,
     COALESCE(likes.like_count, 0) AS like_count, 
     COALESCE(comments.comment_count, 0) AS comment_count
 FROM SHORTS s
 LEFT JOIN USERS u ON s.user_id = u.user_id
 LEFT JOIN BOOK b ON s.book_id = b.book_id
-LEFT JOIN IMAGE i ON u.image_id = i.image_id
-LEFT JOIN IMAGE si ON s.image_id = si.image_id
 LEFT JOIN CATEGORY c ON b.category_id = c.category_id
 LEFT JOIN (
     SELECT shorts_id, COUNT(*) AS like_count


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #19 

## 📝 작업 내용
- 이미지 테이블이 사라지면서 관련 쿼리들을 모두 수정했습니다
- 검색어에 걸리는 쇼츠 아이디값이 없을 경우 `NOT IN ()` 쿼리로 전달되며 에러가 떴었는데 해당 부분에서 검색어에 걸린 쇼츠가 없을 경우에는 바로 카테고리로 조회하는 로직을 타도록 수정하였습니다.
- 쇼츠 상세 조회 API 관련 테스트를 해 보았을 때 모두 정상적으로 응답이 반환되는 것을 확인했습니다.

### 📸 스크린샷 (선택)
<img width="1552" alt="스크린샷 2024-07-30 오전 3 54 26" src="https://github.com/user-attachments/assets/3754b6e4-2495-4eaf-8ac8-d772b077841a">

<img width="1552" alt="스크린샷 2024-07-30 오전 3 54 13" src="https://github.com/user-attachments/assets/5ac5fcd7-a8ed-4a40-b870-cef8d02c7ccd">

<img width="1552" alt="스크린샷 2024-07-30 오전 3 53 51" src="https://github.com/user-attachments/assets/8e643441-853e-4f51-b98f-24f4f82a25fc">

<img width="1552" alt="스크린샷 2024-07-30 오전 3 53 42" src="https://github.com/user-attachments/assets/5846e11a-4c9a-4a07-bcdc-128655bd2d4d">

<img width="1552" alt="스크린샷 2024-07-30 오전 3 53 24" src="https://github.com/user-attachments/assets/45bbd861-352d-49f9-ad28-45e65a452cd3">

<img width="1552" alt="스크린샷 2024-07-30 오전 3 53 10" src="https://github.com/user-attachments/assets/bac7c2fa-0bf2-4dd4-ac18-e1e6e8fed1ea">

## 💬 리뷰 요구사항(선택)
- 혹시 누락된 예외 사항이 있다면 알려주세요!
