### PR TITLE
✨[FEAT] #78: 내 채팅방 조회 기능 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -23,7 +23,7 @@ export const status = {
 
     // community arr
     COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
-    INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
+    INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)이 4인 미만 혹은 10인 초과입니다." },
     COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4003", message: "참여 인원 초과로 참여하실 수 없습니다." },
     ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4004", message: "이미 이 커뮤니티에 참여 중입니다." },
 

--- a/src/book/book.dto.js
+++ b/src/book/book.dto.js
@@ -1,6 +1,20 @@
 import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
 
+export const bookInfoDto = (data) => {
+    if (!data || !data.ISBN || !data.bookTitle || !data.cid || !data.bookCover || !data.author || !data.link) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+
+    return {
+        "ISBN": data.ISBN,
+        "title": data.bookTitle,
+        "image_url": data.bookCover,
+        "author": data.author,
+        "link": data.link
+    };
+};
+
 export const bookSearchResponseDto = (data) => {
     const books = aladinBookSearchResultDto(data);
     const result = books.map(book => {

--- a/src/book/book.dto.js
+++ b/src/book/book.dto.js
@@ -28,7 +28,6 @@ export const bookInfoDto = (data) => {
         "title": data.bookTitle,
         "image_url": data.bookCover,
         "author": data.author,
-        "translator": data.translator,
         "link": data.link
     };
 };

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -1,6 +1,7 @@
 import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { response } from '../../config/response.js';
+import { pageInfo } from "../../config/pageInfo.js";
 import { createCommunityService, joinCommunityService, getCommunitiesService } from './communities.service.js';
 
 // 커뮤니티 생성
@@ -40,18 +41,16 @@ export const joinCommunityController = async (req, res, next) => {
 
 };
 
-
+// 전체 모임 리스트 조회
 export const getCommunitiesController = async (req, res, next) => {
     const page = parseInt(req.query.page) || 1;
     const size = parseInt(req.query.size) || 10;
+    const offset = (page -1) * size
 
-    const { communityList, pageInfo } = await getCommunitiesService(page, size);
+    const result = await getCommunitiesService(offset, size+1)
 
-    res.status(status.SUCCESS.status).send({
-        isSuccess: true,
-        code: status.SUCCESS.code,
-        message: "전체 모임 리스트 불러오기 성공",
-        pageInfo: pageInfo,
-        result: communityList
-    });
-};
+    const hasNext = result.length > size;
+    if (hasNext) result.pop();
+    
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
+}

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -13,8 +13,6 @@ export const createCommunityController = async (req, res, next) => {
 
     const community = creatCommunityDto(req.body, userId);
 
-    console.log("컨트롤러. 커뮤니티 dto" , community);
-
     const communityId = await createCommunityService(book, community, req.body.cid);
 
     if(!communityId) {

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -87,7 +87,9 @@ export const getMyCommunitiesController = async (req, res, next) => {
 
 // 커뮤니티 검색
 export const searchCommunityController = async (req, res, next) => {
-    const { keyword, page = 1, size = 10 } = req.query;
+    const keyword = req.query.keyword;
+    const page = parseInt(req.query.page) || 1;
+    const size = parseInt(req.query.size) || 10;
 
     // 파라미터 검증
     if (!keyword || page <= 0 || size <= 0 || keyword.trim() === "") {

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -2,28 +2,25 @@ import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { response } from '../../config/response.js';
 import { pageInfo } from "../../config/pageInfo.js";
+import { bookInfoDto } from "../book/book.dto.js";
+import { creatCommunityDto } from './communities.dto.js';
 import { createCommunityService, joinCommunityService, getCommunitiesService, getMyCommunitiesService } from './communities.service.js';
 
-// 커뮤니티 생성
+// 커뮤니티 생성 - 책정보 + 내용, 태그, 참여인원, 만남장소
 export const createCommunityController = async (req, res, next) => {
     const userId = req.user_id;
-    const { bookId, address, tag, capacity } = req.body;
+    const book = bookInfoDto(req.body);
 
-    // 누락된 파라미터 확인
-    const missingParams = [];
-    if (!userId) missingParams.push('userId');
-    if (!bookId) missingParams.push('bookId');
-    if (!address) missingParams.push('address');
-    if (!capacity) missingParams.push('capacity');
+    const community = creatCommunityDto(req.body, userId);
 
-    // 누락된 정보가 있을 경우
-    if (missingParams.length > 0) {
-        return next(new BaseError(status.PARAMETER_IS_WRONG));
+    console.log("컨트롤러. 커뮤니티 dto" , community);
+
+    const communityId = await createCommunityService(book, community, req.body.cid);
+
+    if(!communityId) {
+        throw new BaseError(status.INTERNAL_SERVER_ERROR);
     }
 
-    await createCommunityService(userId, bookId, address, tag, capacity);
-
-    // 성공 응답 전송
     res.send(response(status.CREATED));
 };
 

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -2,7 +2,7 @@ import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { response } from '../../config/response.js';
 import { pageInfo } from "../../config/pageInfo.js";
-import { createCommunityService, joinCommunityService, getCommunitiesService } from './communities.service.js';
+import { createCommunityService, joinCommunityService, getCommunitiesService, getMyCommunitiesService } from './communities.service.js';
 
 // 커뮤니티 생성
 export const createCommunityController = async (req, res, next) => {
@@ -48,6 +48,22 @@ export const getCommunitiesController = async (req, res, next) => {
     const offset = (page -1) * size
 
     const result = await getCommunitiesService(offset, size+1)
+
+    const hasNext = result.length > size;
+    if (hasNext) result.pop();
+
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
+}
+
+// 나의 모임 리스트 조회
+export const getMyCommunitiesController = async (req, res, next) => {
+    const page = parseInt(req.query.page) || 1;
+    const size = parseInt(req.query.size) || 10;
+    const offset = (page -1) * size
+
+    const myId = req.user_id;
+
+    const result = await getMyCommunitiesService(myId, offset, size+1)
 
     const hasNext = result.length > size;
     if (hasNext) result.pop();

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -82,7 +82,16 @@ export const getMyCommunitiesController = async (req, res, next) => {
 // 커뮤니티 검색
 export const searchCommunityController = async (req, res, next) => {
     const { keyword, page = 1, size = 10 } = req.query;
-    const result = await searchCommunityService(keyword, page, size);
 
-    res.send(response(status.SUCCESS, result.communityList, result.pageInfo))
+    // 파라미터 검증
+    if (!keyword || page <= 0 || size <= 0 || keyword.trim() === "") {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+    const offset = (page -1) * size
+    const result = await searchCommunityService(keyword, offset, size+1)
+
+    const hasNext = result.length > size;
+    if (hasNext) result.pop();
+    
+    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)))
 };

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -2,18 +2,24 @@ import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { response } from '../../config/response.js';
 import { pageInfo } from "../../config/pageInfo.js";
-import { bookInfoDto } from "../book/book.dto.js";
+import { createBook } from "../book/book.service.js";
 import { creatCommunityDto } from './communities.dto.js';
 import { createCommunityService, joinCommunityService, searchCommunityService, getCommunitiesService, getMyCommunitiesService, deleteCommunityService } from './communities.service.js';
 
 // 커뮤니티 생성 - 책정보 + 내용, 태그, 참여인원, 만남장소
 export const createCommunityController = async (req, res, next) => {
+    const ISBN = req.body.ISBN;
     const userId = req.user_id;
-    const book = bookInfoDto(req.body);
 
+    if(!ISBN) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+
+    const bookId = await createBook(req.body.ISBN);
     const community = creatCommunityDto(req.body, userId);
+    community.book_id = bookId;
 
-    const communityId = await createCommunityService(book, community, req.body.cid);
+    const communityId = await createCommunityService(community);
 
     if(!communityId) {
         throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -9,6 +9,7 @@ export const createCommunity = async (community) => {
     const conn = await pool.getConnection();
     try {
         await conn.query('BEGIN');
+
         const communityId = await insertObject(conn, "COMMUNITY", community);
 
         // 방장을 커뮤니티에 추가
@@ -97,18 +98,17 @@ export const joinCommunity = async (communityId, userId) => {
     }
 };
 
-// 모임 리스트 조회
+// 전체 모임 리스트 조회
 export const getCommunities = async (offset, limit) => {
     const conn = await pool.getConnection();
-    try{
-        const [communities] = await conn.query(sql.GET_COMMUNITIES, [limit, offset]);
-        
+    try {
+        const [communities] = await conn.query(sql.getCommunities, [offset, limit]);
         return communities;
-    }catch (err) {
-        console.log(err);
+    } catch (err) {
+        console.error(err);
         throw err;
     } finally {
-        if(conn) conn.release();
+        if (conn) conn.release();
     }
 };
 
@@ -152,7 +152,7 @@ export const getUnreadCnt = async (communityId, myId) => {
     const conn = await pool.getConnection();
     try {
         const [result] =  await conn.query(sql.getUnreadCount, [myId, communityId])
-        return result[0];
+        return result[0].unread;
     } catch (err) {
         console.log(err);
         throw err;
@@ -162,10 +162,10 @@ export const getUnreadCnt = async (communityId, myId) => {
 }
 
 // 제목으로 커뮤니티 검색
-export const searchCommunitiesByTitleKeyword = async (keyword) => {
+export const searchCommunitiesByTitleKeyword = async (keyword, offset, limit) => {
     const conn = await pool.getConnection();
     try {
-        const [results] = await conn.query(sql.GET_COMMUNITIES_BY_TITLE_KEYWORD, [keyword]);
+        const [results] = await conn.query(sql.GET_COMMUNITIES_BY_TITLE_KEYWORD, [keyword, limit, offset ]);
         return results;
     } catch (err) {
         console.log(err);
@@ -176,10 +176,10 @@ export const searchCommunitiesByTitleKeyword = async (keyword) => {
 };
 
 // 태그로 커뮤니티 검색
-export const searchCommunitiesByTagKeyword = async (keyword) => {
+export const searchCommunitiesByTagKeyword = async (keyword, offset, limit) => {
     const conn = await pool.getConnection()
     try {
-        const [shortsTag] = await conn.query(sql.GET_COMMUNITIES_BY_TAG_KEYWORD, [`%${keyword}%`]);
+        const [shortsTag] = await conn.query(sql.GET_COMMUNITIES_BY_TAG_KEYWORD, [`%${keyword}%`, limit, offset ]);
         return shortsTag;
     } catch (err) {
         console.log(err);

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -2,28 +2,32 @@ import { pool } from '../../config/db.config.js';
 import * as sql from "./communities.sql.js";
 import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
-// 커뮤니티 생성과 관련된 전체 과정 처리
-export const createCommunityWithCheck = async (userId, bookId, address, tag, capacity) => {
-    const conn = await pool.getConnection();
+
+// 커뮤니티 생성
+export const createCommunity = async (community, bookId) => {
+    let conn;
 
     try {
+        conn = await pool.getConnection();
+
         await conn.query('BEGIN'); // 트랜잭션 시작
 
         // 사용자가 특정 책으로 생성한 모임 수 조회
-        const [countResult] = await conn.query(sql.COUNT_COMMUNITIES_BY_USER_AND_BOOK, [userId, bookId]);
+        const [countResult] = await conn.query(sql.COUNT_COMMUNITIES_BY_USER_AND_BOOK, [community.user_id, bookId]);
         const existingCount = countResult[0].count;
 
+        console.log("한 사용자가 해당 책으로 생성한 모임 수", countResult)
         // 한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없도록 제한
         if (existingCount >= 5) {
             throw new BaseError(status.COMMUNITY_LIMIT_EXCEEDED);
         }
 
-        // 커뮤니티 생성
-        const [communityResult] = await conn.query(sql.CREATE_COMMUNITY, [userId, bookId, address, tag, capacity]);
+        // 커뮤니티 생성 (user_id, book_id, content, location, tag, capacity)
+        const [communityResult] = await conn.query(sql.CREATE_COMMUNITY, [community.user_id, bookId, community.content, community.location, community.tag, community.capacity] );
         const communityId = communityResult.insertId;
 
         // 방장을 커뮤니티에 추가
-        await conn.query(sql.ADD_ADMIN_TO_COMMUNITY, [communityId, userId]);
+        await conn.query(sql.ADD_ADMIN_TO_COMMUNITY, [communityId, community.user_id]);
 
         await conn.query('COMMIT'); // 트랜잭션 커밋
         return communityId;
@@ -36,9 +40,6 @@ export const createCommunityWithCheck = async (userId, bookId, address, tag, cap
         } else {
             throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
-    } finally {
-        console.log('finally');
-        conn.release(); // 연결 해제
     }
 };
 
@@ -63,7 +64,7 @@ export const isUserAlreadyInCommunity = async (communityId, userId) => {
 
 // 커뮤니티 가입 처리
 export const joinCommunity = async (communityId, userId) => {
-    await pool.query(JOIN_COMMUNITY, [communityId, userId]);
+    await pool.query(sql.JOIN_COMMUNITY, [communityId, userId]);
 };
 
 // 모임 리스트 조회
@@ -88,7 +89,7 @@ export const getMyCommunities = async (myId, offset, limit) => {
     try{
         const conn = await pool.getConnection();
         const [communities] = await pool.query(sql.getMyCommunities, [myId, limit, offset]);
-        
+
         conn.release();
 
         return communities;

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -5,24 +5,21 @@ import { status } from '../../config/response.status.js';
 
 // 커뮤니티 생성
 export const createCommunity = async (community, bookId) => {
-    let conn;
+    const conn = await pool.getConnection();
 
     try {
-        conn = await pool.getConnection();
-
         await conn.query('BEGIN'); // 트랜잭션 시작
 
         // 사용자가 특정 책으로 생성한 모임 수 조회
         const [countResult] = await conn.query(sql.COUNT_COMMUNITIES_BY_USER_AND_BOOK, [community.user_id, bookId]);
         const existingCount = countResult[0].count;
 
-        console.log("한 사용자가 해당 책으로 생성한 모임 수", countResult)
         // 한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없도록 제한
         if (existingCount >= 5) {
             throw new BaseError(status.COMMUNITY_LIMIT_EXCEEDED);
         }
 
-        // 커뮤니티 생성 (user_id, book_id, content, location, tag, capacity)
+        // 커뮤니티 생성
         const [communityResult] = await conn.query(sql.CREATE_COMMUNITY, [community.user_id, bookId, community.content, community.location, community.tag, community.capacity] );
         const communityId = communityResult.insertId;
 
@@ -40,92 +37,128 @@ export const createCommunity = async (community, bookId) => {
         } else {
             throw new BaseError(status.INTERNAL_SERVER_ERROR);
         }
+    } finally {
+        if(conn) conn.release();
     }
+    
 };
 
 
 // 커뮤니티의 현재 참여자 수를 조회하는 함수
 export const getCommunityCurrentCount = async (communityId) => {
-    const [result] = await pool.query(sql.GET_COMMUNITY_CURRENT_COUNT, [communityId]);
-    return result[0].count;
+    const conn = await pool.getConnection();
+    try {
+        const [result] = await conn.query(sql.GET_COMMUNITY_CURRENT_COUNT, [communityId]);
+        return result[0].count;
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 };
 
 // 커뮤니티의 최대 인원수를 조회하는 함수
 export const getCommunityCapacity = async (communityId) => {
-    const [result] = await pool.query(sql.GET_COMMUNITY_CAPACITY, [communityId]);
-    return result[0].capacity;
+    const conn = await pool.getConnection();
+    try {
+        const [result] = await conn.query(sql.GET_COMMUNITY_CAPACITY, [communityId]);
+        return result[0].capacity;
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 };
 
 // 사용자가 이미 커뮤니티에 참여하고 있는지 확인하는 함수
 export const isUserAlreadyInCommunity = async (communityId, userId) => {
-    const [result] = await pool.query(sql.IS_USER_ALREADY_IN_COMMUNITY, [communityId, userId]);
-    return result[0].count > 0;
+    const conn = await pool.getConnection();
+    try {
+        const [result] = await conn.query(sql.IS_USER_ALREADY_IN_COMMUNITY, [communityId, userId]);
+        return result[0].count > 0;
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 };
 
 // 커뮤니티 가입 처리
 export const joinCommunity = async (communityId, userId) => {
-    await pool.query(sql.JOIN_COMMUNITY, [communityId, userId]);
+    const conn = await pool.getConnection();
+    try {
+        await conn.query(sql.JOIN_COMMUNITY, [communityId, userId]);
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 };
 
 // 모임 리스트 조회
 export const getCommunities = async (offset, limit) => {
-    
+    const conn = await pool.getConnection();
     try{
-        const conn = await pool.getConnection();
-        const [communities] = await pool.query(sql.GET_COMMUNITIES, [limit, offset]);
+        const [communities] = await conn.query(sql.GET_COMMUNITIES, [limit, offset]);
         
-        conn.release();
-
         return communities;
-    }
-    catch (err) {
+    }catch (err) {
         console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
     }
 };
 
 // 나의 참여 모임 리스트 조회
 export const getMyCommunities = async (myId, offset, limit) => {
-    
-    try{
-        const conn = await pool.getConnection();
-        const [communities] = await pool.query(sql.getMyCommunities, [myId, limit, offset]);
-
-        conn.release();
+    const conn = await pool.getConnection();
+    try {
+        const [communities] = await conn.query(sql.getMyCommunities, [myId, limit, offset]);
 
         return communities;
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
     }
 };
 
 // 커뮤니티 책 제목, 표지 불러오기
 export const getCommunityBookInfo = async (communityId) => {
+    const conn = await pool.getConnection();
+    try {
+        // 모임에서 선택된 책 id 불러오기
+        const [bookIdResult] = await conn.query(sql.getCommunityBookID, [communityId]);
+        const bookId = bookIdResult[0].book_id;
 
-    // 모임에서 선택된 책 id 불러오기
-    const [bookIdResult] = await pool.query(sql.getCommunityBookID, [communityId]);
-    const bookId = bookIdResult[0].book_id;
+        // 해당 책의 표지와 제목 불러오기
+        const [result] = await conn.query(sql.getBookInfo, [bookId]);
 
-    // 해당 책의 표지와 제목 불러오기
-    const [result] = await pool.query(sql.getBookInfo, [bookId]);
-
-    return result[0]
+        return result[0]
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 };
 
 // 안읽은 메시지 개수 
-export const getUnreadCnt = async (myId) => {
-    
+export const getUnreadCnt = async (communityId, myId) => {
     const conn = await pool.getConnection();
-    const [result] =  await conn.query(sql.getUnreadCount, myId, (err, rows) => {
-        conn.release();
-        
-        if (err) {
-            console.log(err);
-            throw err;
-        } else {
-            return rows;
-        }
-    });
-    
-    return result[0];
+    try {
+        const [result] =  await conn.query(sql.getUnreadCount, [myId, communityId])
+        return result[0];
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        if(conn) conn.release();
+    }
 }

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -102,7 +102,7 @@ export const joinCommunity = async (communityId, userId) => {
 export const getCommunities = async (offset, limit) => {
     const conn = await pool.getConnection();
     try {
-        const [communities] = await conn.query(sql.getCommunities, [offset, limit]);
+        const [communities] = await conn.query(sql.getCommunities, [limit, offset]);
         return communities;
     } catch (err) {
         console.error(err);
@@ -116,8 +116,7 @@ export const getCommunities = async (offset, limit) => {
 export const getMyCommunities = async (myId, offset, limit) => {
     const conn = await pool.getConnection();
     try {
-        const [communities] = await conn.query(sql.getMyCommunities, [myId, limit, offset]);
-
+        const [communities] = await conn.query(sql.getMyCommunities, [myId, myId, limit, offset]);
         return communities;
     } catch (err) {
         console.log(err);

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -126,40 +126,6 @@ export const getMyCommunities = async (myId, offset, limit) => {
     }
 };
 
-// 커뮤니티 책 제목, 표지 불러오기
-export const getCommunityBookInfo = async (communityId) => {
-    const conn = await pool.getConnection();
-    try {
-        // 모임에서 선택된 책 id 불러오기
-        const [bookIdResult] = await conn.query(sql.getCommunityBookID, [communityId]);
-        const bookId = bookIdResult[0].book_id;
-
-        // 해당 책의 표지와 제목 불러오기
-        const [result] = await conn.query(sql.getBookInfo, [bookId]);
-
-        return result[0]
-    } catch (err) {
-        console.log(err);
-        throw err;
-    } finally {
-        if(conn) conn.release();
-    }
-};
-
-// 안읽은 메시지 개수 
-export const getUnreadCnt = async (communityId, myId) => {
-    const conn = await pool.getConnection();
-    try {
-        const [result] =  await conn.query(sql.getUnreadCount, [myId, communityId])
-        return result[0].unread;
-    } catch (err) {
-        console.log(err);
-        throw err;
-    } finally {
-        if(conn) conn.release();
-    }
-}
-
 // 제목으로 커뮤니티 검색
 export const searchCommunitiesByTitleKeyword = async (keyword, offset, limit) => {
     const conn = await pool.getConnection();

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -9,7 +9,7 @@ export const communitiesInfoDTO = (community, communityBook, currentCount) => {
         "bookTitle" : communityBook.title,
         "Participants" : currentCount,
         "capacity" : community.capacity,
-        "tags" : community.tag ? community.tag.split('|') : [],
+        "tag": community.tags,
         "location" : community.location
     }
 };
@@ -22,14 +22,14 @@ export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unr
         "bookTitle" : communityBook.title,
         "Participants" : currentCount,
         "capacity" : community.capacity,
-        "tags" : community.tag ? community.tag.split('|') : [],
+        "tag": community.tags,
         "location" : community.location,
         "unReadCount" : unreadCnt
     }
 }; 
 
-// 쇼츠 생성 때 입력되는 필수값들
-export const creatCommunityDto= (data, userId) => {
+// 커뮤니티 생성 때 입력되는 필수값들
+export const creatCommunityDto = (data, userId) => {
     if (!data || !data.tags || !data.capacity || !data.location || !data.content ) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -6,6 +6,19 @@ export const communitiesInfoDTO = (community, communityBook, currentCount) => {
         "Participants" : currentCount,
         "capacity" : community.capacity,
         "tags" : community.tag ? community.tag.split('|') : [],
-        "address" : community.address
+        "address" : community.location
     }
 };
+
+export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unreadCnt) => {
+    
+    return{   
+    "bookImg" : communityBook.image_url,
+        "bookTitle" : communityBook.title,
+        "Participants" : currentCount,
+        "capacity" : community.capacity,
+        "tags" : community.tag ? community.tag.split('|') : [],
+        "address" : community.location,
+        "unReadCount" : unreadCnt
+    }
+}; 

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -2,30 +2,28 @@ import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
 
 // 커뮤니티 상세
-export const communitiesInfoDTO = (community, communityBook, currentCount, tagsList) => {
-    
-    return{   
-        "bookImg" : communityBook.link,
-        "bookTitle" : communityBook.title,
-        "Participants" : currentCount,
+export const communitiesInfoDTO = (community) => {
+    return {
+        "bookImg": community.bookImg,
+        "bookTitle": community.title,   
+        "Participants" : community.currentCount,
         "capacity" : community.capacity,
-        "tags": tagsList,
+        "tags": community.tag ? community.tag.split("|") : [],
         "location" : community.location,
         "community_id" : community.community_id
     }
-};
+}; 
 
 // 내가 참여한 커뮤니티 상세
-export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unreadCnt, tagsList) => {
-    
-    return{   
-        "bookImg" : communityBook.link,
-        "bookTitle" : communityBook.title,
-        "Participants" : currentCount,
+export const mycommunitiesInfoDTO = (community) => {
+    return {
+        "bookImg": community.bookImg,
+        "bookTitle": community.title,   
+        "Participants" : community.currentCount,
         "capacity" : community.capacity,
-        "tags": tagsList,
+        "tags": community.tag ? community.tag.split("|") : [],
         "location" : community.location,
-        "unReadCount" : unreadCnt,
+        "unReadCount" : community.unreadCnt,
         "community_id" : community.community_id
     }
 }; 

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -10,7 +10,8 @@ export const communitiesInfoDTO = (community, communityBook, currentCount, tagsL
         "Participants" : currentCount,
         "capacity" : community.capacity,
         "tags": tagsList,
-        "location" : community.location
+        "location" : community.location,
+        "community_id" : community.community_id
     }
 };
 
@@ -24,7 +25,8 @@ export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unr
         "capacity" : community.capacity,
         "tags": tagsList,
         "location" : community.location,
-        "unReadCount" : unreadCnt
+        "unReadCount" : unreadCnt,
+        "community_id" : community.community_id
     }
 }; 
 

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -1,3 +1,6 @@
+import { BaseError } from "../../config/error.js";
+import { status } from "../../config/response.status.js";
+
 export const communitiesInfoDTO = (community, communityBook, currentCount) => {
     
     return{   
@@ -6,7 +9,7 @@ export const communitiesInfoDTO = (community, communityBook, currentCount) => {
         "Participants" : currentCount,
         "capacity" : community.capacity,
         "tags" : community.tag ? community.tag.split('|') : [],
-        "address" : community.location
+        "location" : community.location
     }
 };
 
@@ -18,7 +21,22 @@ export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unr
         "Participants" : currentCount,
         "capacity" : community.capacity,
         "tags" : community.tag ? community.tag.split('|') : [],
-        "address" : community.location,
+        "location" : community.location,
         "unReadCount" : unreadCnt
     }
 }; 
+
+// 쇼츠 생성 때 입력되는 필수값들
+export const creatCommunityDto= (data, userId) => {
+    if (!data || !data.tags || !data.capacity || !data.location || !data.content ) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+
+    return {
+        "content": data.content,
+        "tag": data.tags,
+        "capacity" : data.capacity,
+        "location" : data.location,
+        "user_id": userId
+    };
+}

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -2,27 +2,27 @@ import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
 
 // 커뮤니티 상세
-export const communitiesInfoDTO = (community, communityBook, currentCount) => {
+export const communitiesInfoDTO = (community, communityBook, currentCount, tagsList) => {
     
     return{   
-        "bookImg" : communityBook.image_url,
+        "bookImg" : communityBook.link,
         "bookTitle" : communityBook.title,
         "Participants" : currentCount,
         "capacity" : community.capacity,
-        "tag": community.tags,
+        "tags": tagsList,
         "location" : community.location
     }
 };
 
 // 내가 참여한 커뮤니티 상세
-export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unreadCnt) => {
+export const mycommunitiesInfoDTO = (community, communityBook, currentCount, unreadCnt, tagsList) => {
     
     return{   
-    "bookImg" : communityBook.image_url,
+        "bookImg" : communityBook.link,
         "bookTitle" : communityBook.title,
         "Participants" : currentCount,
         "capacity" : community.capacity,
-        "tag": community.tags,
+        "tags": tagsList,
         "location" : community.location,
         "unReadCount" : unreadCnt
     }
@@ -42,17 +42,3 @@ export const creatCommunityDto = (data, userId) => {
         "user_id": userId
     };
 }
-
-// DTO 변환 함수
-export const getCommunitiesDto = (data) => {
-    return data.communities.map(community => ({
-        communityId: community.community_id,
-        userId: community.user_id,
-        bookId: community.book_id,
-        address: community.address ? community.address.split('|') : [], // check for undefined
-        tags: community.tag ? community.tag.split('|') : [],
-        capacity: community.capacity,
-        createdAt: community.created_at,
-        updatedAt: community.updated_at
-    }));
-};

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -1,12 +1,11 @@
-export const getCommunitiesDto = (data) => {
-    return data.communities.map(community => ({
-        communityId: community.community_id,
-        userId: community.user_id,
-        bookId: community.book_id,
-        address: community.address.split('|'),
-        tags: community.tag ? community.tag.split('|') : [],
-        capacity: community.capacity,
-        createdAt: community.created_at,
-        updatedAt: community.updated_at
-    }));
+export const communitiesInfoDTO = (community, communityBook, currentCount) => {
+    
+    return{   
+        "bookImg" : communityBook.image_url,
+        "bookTitle" : communityBook.title,
+        "Participants" : currentCount,
+        "capacity" : community.capacity,
+        "tags" : community.tag ? community.tag.split('|') : [],
+        "address" : community.address
+    }
 };

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -1,7 +1,12 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { createCommunityController, joinCommunityController, getCommunitiesController, getMyCommunitiesController, searchCommunityController, deleteCommunityController } from './communities.controllers.js';
+import { createCommunityController, 
+    joinCommunityController, 
+    getCommunitiesController, 
+    getMyCommunitiesController, 
+    searchCommunityController, 
+    deleteCommunityController } from './communities.controllers.js';
 import { authJWT } from '../jwt/authJWT.js';
 
 export const communitiesRouter = express.Router();

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { createCommunityController,joinCommunityController,getCommunitiesController } from './communities.controllers.js';
+import { createCommunityController,joinCommunityController,getCommunitiesController, getMyCommunitiesController } from './communities.controllers.js';
 import { authJWT } from '../jwt/authJWT.js';
 
 export const communitiesRouter = express.Router();
@@ -9,7 +9,7 @@ export const communitiesRouter = express.Router();
 communitiesRouter.get('/', asyncHandler(getCommunitiesController));
 
 // 나의 참여 모임 조회
-communitiesRouter.get('/my', asyncHandler(authJWT), asyncHandler(getCommunitiesController));
+communitiesRouter.get('/my', asyncHandler(authJWT), asyncHandler(getMyCommunitiesController));
 
 // 모임 생성
 communitiesRouter.post('/', asyncHandler(authJWT), asyncHandler(createCommunityController));

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -5,7 +5,15 @@ import { authJWT } from '../jwt/authJWT.js';
 
 export const communitiesRouter = express.Router();
 
+// 모임 조회
 communitiesRouter.get('/', asyncHandler(getCommunitiesController));
+
+// 나의 참여 모임 조회
+communitiesRouter.get('/my', asyncHandler(authJWT), asyncHandler(getCommunitiesController));
+
+// 모임 생성
 communitiesRouter.post('/', asyncHandler(authJWT), asyncHandler(createCommunityController));
+
+// 모임 참여
 communitiesRouter.post('/:communityId', asyncHandler(authJWT), asyncHandler(joinCommunityController));
 

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -1,34 +1,7 @@
 import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
-
-import {
-    deleteCommunityDao,
-    checkCommunityExistenceDao,
-    checkCommunityOwnerDao,
-    getCommunities,
-    getCommunityCurrentCountDao,
-    getCommunityCapacityDao,
-    joinCommunity,
-    checkUserInCommunity,
-    rejoinCommunity,
-    leaveCommunityDao,
-    getCommunityDetailsDao,
-    getChatroomDetailsDao,
-    updateMeetingDetailsDao,
-    getCommunityUpdatedAtDao,
-    searchCommunitiesByTagKeyword,
-    searchCommunitiesByTitleKeyword,
-    checkIfLeaderDao,
-    getMyCommunities,
-    createCommunity,
-    isUserAlreadyInCommunity,
-    deleteCommunityDao,
-    checkCommunityExistenceDao,
-    checkCommunityOwnerDao,
-    isPossibleCreateCommunity,
-} from './communities.dao.js';
-import { getCommunitiesDto, getCommunityDetailsDto, getChatroomDetailsDto, communitiesInfoDTO, mycommunitiesInfoDTO } from './communities.dto.js';
-import { pageInfo } from '../../config/pageInfo.js';
+import * as dao from './communities.dao.js';
+import { getCommunityDetailsDto, getChatroomDetailsDto, communitiesInfoDTO, mycommunitiesInfoDTO } from './communities.dto.js';
 
 
 // 커뮤니티 생성 서비스
@@ -55,12 +28,12 @@ export const createCommunityService = async (community) => {
     }
 
     // 방장이 모임 생성 가능한지 확인
-    if(!isPossibleCreateCommunity(community.user_id, community.book_id)) {
+    if(!dao.isPossibleCreateCommunity(community.user_id, community.book_id)) {
         throw new BaseError(status.COMMUNITY_LIMIT_EXCEEDED);
     }
 
     // 모임 생성
-    return await createCommunity(community);
+    return await dao.createCommunity(community);
 };
 
 //커뮤니티 가입 서비스
@@ -68,7 +41,7 @@ export const joinCommunityService = async (communityId, userId) => {
     // 유저가 커뮤니티에 이미 존재하는지 확인하고 is_deleted 상태 반환
     const userStatus = await checkUserInCommunity(communityId, userId);
     // 커뮤니티의 현재 인원수 및 최대 인원수 조회
-    const currentCount = await getCommunityCurrentCountDao(communityId);
+    const currentCount = await dao.getCommunityCurrentCountDao(communityId);
 
     // 현재 인원수가 최대 인원수를 초과하면 오류 발생
     const capacity = await getCommunityCapacityDao(communityId);
@@ -77,10 +50,10 @@ export const joinCommunityService = async (communityId, userId) => {
     }
     if (userStatus === null) {
         // 디비에 유저 정보가 없으면 새로 가입 처리
-        await joinCommunity(communityId, userId);
+        await dao.joinCommunity(communityId, userId);
     } else if (userStatus) {
         // 유저가 탈퇴한 경우, 재가입 처리
-        await rejoinCommunity(communityId, userId);
+        await dao.rejoinCommunity(communityId, userId);
     } else {
         // 유저가 이미 가입되어 있는 경우 오류 발생
         throw new BaseError(status.ALREADY_IN_COMMUNITY);
@@ -90,7 +63,7 @@ export const joinCommunityService = async (communityId, userId) => {
 
 // 전체 모임 리스트 조회
 export const getCommunitiesService = async (offset, limit) => {
-    const allCommunities = await getCommunities(offset, limit);
+    const allCommunities = await dao.getCommunities(offset, limit);
 
     // DTO 내부 로직으로 처리
     const allCommunitiesDTOList = allCommunities.map(c => communitiesInfoDTO(c));
@@ -100,7 +73,7 @@ export const getCommunitiesService = async (offset, limit) => {
 
 // 나의 참여 모임 리스트 조회
 export const getMyCommunitiesService = async (myId, offset, limit) => {
-    const myCommunities = await getMyCommunities(myId, offset, limit);
+    const myCommunities = await dao.getMyCommunities(myId, offset, limit);
 
     // DTO 내부 로직으로 처리
     const myCommunitiesDTOList = myCommunities.map(c => mycommunitiesInfoDTO(c));
@@ -117,14 +90,8 @@ export const searchCommunityService = async (keyword, offset, limit) => {
 
     // 태그 또는 제목 검색
     const searchCommunities = isTagSearch 
-        ? await searchCommunitiesByTagKeyword(decodedKeyword.substring(1), offset, limit) // 태그 검색 ('#은 제거')
-        : await searchCommunitiesByTitleKeyword(decodedKeyword, offset, limit); // 제목 검색
-
-    // DTO 내부 로직으로 처리
-    const searchCommunitiesDTOList = searchCommunities.map(c => communitiesInfoDTO(c));
-
-    return searchCommunitiesDTOList; // 결과 리스트 반환
-};
+        ? await dao.searchCommunitiesByTagKeyword(decodedKeyword.substring(1), offset, limit) // 태그 검색 ('#은 제거')
+        : await dao.searchCommunitiesByTitleKeyword(decodedKeyword, offset, limit); // 제목 검색
 
     // DTO 내부 로직으로 처리
     const searchCommunitiesDTOList = searchCommunities.map(c => communitiesInfoDTO(c));
@@ -133,17 +100,17 @@ export const searchCommunityService = async (keyword, offset, limit) => {
 };
 
 export const deleteCommunityService = async (user_id, community_id) => {
-    const exists = await checkCommunityExistenceDao(community_id);
+    const exists = await dao.checkCommunityExistenceDao(community_id);
     if (!exists) {
         throw new BaseError(status.COMMUNITY_NOT_FOUND);
     }
 
-    const owner = await checkCommunityOwnerDao(community_id);
+    const owner = await dao.checkCommunityOwnerDao(community_id);
     if (owner !== user_id) {
         throw new BaseError(status.UNAUTHORIZED);
     }
 
-    await deleteCommunityDao(community_id);
+    await dao.deleteCommunityDao(community_id);
 };
   
 export const leaveCommunityService = async (communityId, userId) => {
@@ -155,19 +122,19 @@ export const leaveCommunityService = async (communityId, userId) => {
     }
 
     // 유저가 방장인지 확인
-    const isLeader = await checkIfLeaderDao(communityId, userId);
+    const isLeader = await dao.checkIfLeaderDao(communityId, userId);
     if (isLeader) {
         // 방장은 탈퇴할 수 없음
         throw new BaseError(status.LEADER_CANNOT_LEAVE);
     }
 
     // 유저 탈퇴 처리 (소프트 딜리트 및 삭제 시간 기록)
-    await leaveCommunityDao(communityId, userId);
+    await dao.leaveCommunityDao(communityId, userId);
 };
 
 // 커뮤니티 상세정보를 가져오는 서비스 함수
 export const getCommunityDetailsService = async (communityId, userId) => {
-    const communityData = await getCommunityDetailsDao(communityId);
+    const communityData = await dao.getCommunityDetailsDao(communityId);
     let isUserParticipating = false;
 
 
@@ -191,7 +158,7 @@ export const getChatroomDetailsService = async (communityId, currentUserId) => {
     }
 
     // 커뮤니티 데이터 가져오기
-    const { communityData, membersData } = await getChatroomDetailsDao(communityId);
+    const { communityData, membersData } = await dao.getChatroomDetailsDao(communityId);
     if (!communityData || communityData.length === 0) {
         throw new BaseError(status.NOT_FOUND);
     }
@@ -202,12 +169,12 @@ export const getChatroomDetailsService = async (communityId, currentUserId) => {
 
 export const updateMeetingDetailsService = async (communityId, meetingDate, latitude, longitude, address, userId) => {
 
-    const exists = await checkCommunityExistenceDao(communityId);
+    const exists = await dao.checkCommunityExistenceDao(communityId);
     if (!exists) {
         throw new BaseError(status.COMMUNITY_NOT_FOUND);
     }
 
-    const communityUpdatedAt = await getCommunityUpdatedAtDao(communityId);
+    const communityUpdatedAt = await dao.getCommunityUpdatedAtDao(communityId);
     const updatedAtDate = new Date(communityUpdatedAt);
     const meetingDateDate = new Date(meetingDate);
     const thirtyMinutesInMs = 30 * 60 * 1000;
@@ -218,5 +185,5 @@ export const updateMeetingDetailsService = async (communityId, meetingDate, lati
     }
 
 
-    await updateMeetingDetailsDao(communityId, meetingDate, latitude, longitude, address, userId);
+    await dao.updateMeetingDetailsDao(communityId, meetingDate, latitude, longitude, address, userId);
 };

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -6,8 +6,6 @@ import {
     getMyCommunities,
     createCommunity,
     getCommunityCurrentCount,
-    getUnreadCnt,
-    getCommunityBookInfo,
     getCommunityCapacity,
     isUserAlreadyInCommunity,
     searchCommunitiesByTagKeyword,

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -110,7 +110,7 @@ export const getMyCommunitiesService = async (myId, offset, limit) => {
         let communityBook = await getCommunityBookInfo(c.community_id);
 
         // 안읽음 개수
-        let unreadCnt = await getUnreadCnt(myId);
+        let unreadCnt = await getUnreadCnt(c.community_id, myId);
         unreadCnt = Number(unreadCnt.unread);
         
         let result = mycommunitiesInfoDTO(c, communityBook, currentCount, unreadCnt);

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -2,13 +2,15 @@ import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { 
     getCommunities, 
+    getMyCommunities,
     createCommunityWithCheck, 
     getCommunityCurrentCount,
+    getUnreadCnt,
     getCommunityBookInfo, 
     getCommunityCapacity, 
     isUserAlreadyInCommunity, 
     joinCommunity } from './communities.dao.js';
-import { communitiesInfoDTO } from './communities.dto.js';
+import { communitiesInfoDTO, mycommunitiesInfoDTO } from './communities.dto.js';
 
 // 커뮤니티 생성 서비스
 export const createCommunityService = async (userId, bookId, address, tag, capacity) => {
@@ -77,4 +79,28 @@ export const getCommunitiesService = async (offset, limit) => {
     }
 
     return allCommunitiesDTOList
+};
+
+// 나의 참여 모임 리스트 조회
+export const getMyCommunitiesService = async (myId, offset, limit) => {
+    
+    const myCommunities = await getMyCommunities(myId, offset, limit);
+    const myCommunitiesDTOList = [];
+    
+    for (const c of myCommunities) {
+        //현재 참여자수
+        let currentCount = await getCommunityCurrentCount(c.community_id);
+        
+        // 모임 책 정보
+        let communityBook = await getCommunityBookInfo(c.community_id);
+
+        // 안읽음 개수
+        let unreadCnt = await getUnreadCnt(myId);
+        unreadCnt = Number(unreadCnt.unread);
+        
+        let result = mycommunitiesInfoDTO(c, communityBook, currentCount, unreadCnt);
+        myCommunitiesDTOList.push(result);
+    }
+
+    return myCommunitiesDTOList
 };

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -73,13 +73,8 @@ export const joinCommunityService = async (communityId, userId) => {
 export const getCommunitiesService = async (offset, limit) => {
     const allCommunities = await getCommunities(offset, limit);
 
-    // 결과를 DTO 형식으로 변환
-    const allCommunitiesDTOList = allCommunities.map(c => {
-        
-        const tagsList = c.tag ? c.tag.split('|') : []; // 태그가 없을 경우, 빈 리스트로
-
-        return communitiesInfoDTO(c, { title: c.title, link: c.link }, c.currentCount, tagsList);
-    });
+    // DTO 내부 로직으로 처리
+    const allCommunitiesDTOList = allCommunities.map(c => communitiesInfoDTO(c));
 
     return allCommunitiesDTOList;
 };
@@ -88,13 +83,8 @@ export const getCommunitiesService = async (offset, limit) => {
 export const getMyCommunitiesService = async (myId, offset, limit) => {
     const myCommunities = await getMyCommunities(myId, offset, limit);
 
-    // 결과를 DTO 형식으로 변환
-    const myCommunitiesDTOList = await Promise.all(myCommunities.map(async (c) => {
-        const tagsList = c.tag ? c.tag.split('|') : []; // 태그가 없을 경우, 빈 리스트로
-        const unreadCnt = await getUnreadCnt(c.community_id, myId); // 비동기 함수 호출 시 await 사용
-
-        return mycommunitiesInfoDTO(c, { title: c.title, link: c.link }, c.currentCount, unreadCnt, tagsList);
-    }));
+    // DTO 내부 로직으로 처리
+    const myCommunitiesDTOList = myCommunities.map(c => mycommunitiesInfoDTO(c));
 
     return myCommunitiesDTOList;
 };
@@ -111,13 +101,8 @@ export const searchCommunityService = async (keyword, offset, limit) => {
         ? await searchCommunitiesByTagKeyword(decodedKeyword.substring(1), offset, limit) // 태그 검색 ('#은 제거')
         : await searchCommunitiesByTitleKeyword(decodedKeyword, offset, limit); // 제목 검색
 
-    // 결과를 DTO 형식으로 변환
-    const searchCommunitiesDTOList = searchCommunities.map(c => {
-        
-        const tagsList = c.tag ? c.tag.split('|') : []; // 태그가 없을 경우, 빈 리스트로
-
-        return communitiesInfoDTO(c, { title: c.title, link: c.link }, c.currentCount, tagsList);
-    });
+    // DTO 내부 로직으로 처리
+    const searchCommunitiesDTOList = searchCommunities.map(c => communitiesInfoDTO(c));
 
     return searchCommunitiesDTOList; // 결과 리스트 반환
 };

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -18,7 +18,8 @@ import {
     checkCommunityOwnerDao,
 } from './communities.dao.js';
 import { communitiesInfoDTO, mycommunitiesInfoDTO, getCommunitiesDto } from './communities.dto.js';
-import { createBook, getBookIdByISBN, getCategoryIdByAladinCid } from "../book/book.dao.js";
+import { getBookIdByISBN, getCategoryIdByAladinCid } from "../book/book.dao.js";
+import { createBook } from "../book/book.service.js";
 import { pageInfo } from '../../config/pageInfo.js';
 
 // 커뮤니티 생성 서비스

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -30,7 +30,7 @@ export const COUNT_COMMUNITIES_BY_USER_AND_BOOK = `
 `;
 
 // 그룹 생성 쿼리
-export const CREATE_COMMUNITY = "INSERT INTO COMMUNITY (user_id, book_id, address, tag, capacity) VALUES (?, ?, ?, ?, ?);";
+export const CREATE_COMMUNITY = "INSERT INTO COMMUNITY (user_id, book_id, content, location, tag, capacity) VALUES (?, ?, ?, ?, ?, ?);";
 
 // 모임 총 개수 조회 쿼리
 export const COUNT_COMMUNITIES = "SELECT COUNT(*) as count FROM COMMUNITY;";
@@ -43,15 +43,18 @@ export const GET_COMMUNITIES = `
 `;
 
 // 나의 참여 모임 리스트 조회 쿼리 (최신 메시지 온 순으로 정렬)
-export const getMyCommunities = `
+export const getMyCommunities =  `
     SELECT c.*
-    FROM COMMUNITY c
+    FROM COMMUNITY_USERS c
     LEFT JOIN MESSAGE m ON c.community_id = m.community_id
-    WHERE c.user_id = ?
+    WHERE c.user_id = ? AND c.is_deleted = 0
     GROUP BY c.community_id
-    ORDER BY MAX(m.created_at) DESC
+    ORDER BY 
+        MAX(m.created_at) DESC,
+        COUNT(m.message_id) ASC  -- 메시지가 없는 경우 아래로 정렬
     LIMIT ? OFFSET ?;
-`
+`;
+
 // 안읽은 개수 조회
 export const getUnreadCount = `
     SELECT COUNT(*) AS unread
@@ -59,7 +62,7 @@ export const getUnreadCount = `
     WHERE m.created_at > (
         SELECT MAX(r.created_at)
         FROM MESSAGE_READ_STATUS r
-        JOIN MESSAGE m ON r.message_id = m.message_id
+        JOIN MESSAGE m ON r.latest_message_id = m.message_id
         WHERE r.user_id = ? ) ;`;
 
 // 커뮤니티 ID로 책 id 조회

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -42,6 +42,26 @@ export const GET_COMMUNITIES = `
     LIMIT ? OFFSET ?;
 `;
 
+// 나의 참여 모임 리스트 조회 쿼리 (최신 메시지 온 순으로 정렬)
+export const getMyCommunities = `
+    SELECT c.*
+    FROM COMMUNITY c
+    LEFT JOIN MESSAGE m ON c.community_id = m.community_id
+    WHERE c.user_id = ?
+    GROUP BY c.community_id
+    ORDER BY MAX(m.created_at) DESC
+    LIMIT ? OFFSET ?;
+`
+// 안읽은 개수 조회
+export const getUnreadCount = `
+    SELECT COUNT(*) AS unread
+    FROM MESSAGE m
+    WHERE m.created_at > (
+        SELECT MAX(r.created_at)
+        FROM MESSAGE_READ_STATUS r
+        JOIN MESSAGE m ON r.message_id = m.message_id
+        WHERE r.user_id = ? ) ;`;
+
 // 커뮤니티 ID로 책 id 조회
 export const getCommunityBookID = "SELECT book_id FROM COMMUNITY WHERE community_id = ?;";
 

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -44,26 +44,42 @@ export const GET_COMMUNITIES = `
 
 // 나의 참여 모임 리스트 조회 쿼리 (최신 메시지 온 순으로 정렬)
 export const getMyCommunities =  `
-    SELECT c.*
-    FROM COMMUNITY_USERS c
-    LEFT JOIN MESSAGE m ON c.community_id = m.community_id
-    WHERE c.user_id = ? AND c.is_deleted = 0
-    GROUP BY c.community_id
+    SELECT cu.*, c.*
+    FROM COMMUNITY_USERS cu
+    LEFT JOIN MESSAGE m ON cu.community_id = m.community_id
+    LEFT JOIN COMMUNITY c ON cu.community_id = c.community_id  -- 커뮤니티 테이블 조인
+    WHERE cu.user_id = ? AND cu.is_deleted = 0
+    GROUP BY cu.community_id
     ORDER BY 
         MAX(m.created_at) DESC,
         COUNT(m.message_id) ASC  -- 메시지가 없는 경우 아래로 정렬
     LIMIT ? OFFSET ?;
 `;
 
-// 안읽은 개수 조회
+
+// 안읽음 개수 카운트
 export const getUnreadCount = `
-    SELECT COUNT(*) AS unread
-    FROM MESSAGE m
-    WHERE m.created_at > (
-        SELECT MAX(r.created_at)
-        FROM MESSAGE_READ_STATUS r
-        JOIN MESSAGE m ON r.latest_message_id = m.message_id
-        WHERE r.user_id = ? ) ;`;
+WITH Params AS (
+    SELECT ? AS user_id, ? AS community_id
+),
+LastReadTime AS (  -- 마지막으로 메시지 읽은 시간
+    SELECT COALESCE(MAX(r.created_at), '1970-01-01') AS last_read_time
+    FROM MESSAGE_READ_STATUS r, Params p
+    WHERE r.user_id = p.user_id AND r.community_id = p.community_id
+), 
+JoinTime AS (  -- 모임 가입 시간
+    SELECT cu.created_at AS join_time
+    FROM COMMUNITY_USERS cu, Params p
+    WHERE cu.user_id = p.user_id AND cu.community_id = p.community_id
+)
+SELECT COUNT(*) AS unread
+FROM MESSAGE m, Params p
+WHERE m.community_id = p.community_id 
+AND m.created_at > (
+    SELECT GREATEST(lr.last_read_time, jt.join_time)
+    FROM LastReadTime lr, JoinTime jt
+);
+`;
 
 // 커뮤니티 ID로 책 id 조회
 export const getCommunityBookID = "SELECT book_id FROM COMMUNITY WHERE community_id = ?;";

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -1,6 +1,6 @@
 // 커뮤니티의 현재 참여자 수를 조회하는 쿼리
 export const GET_COMMUNITY_CURRENT_COUNT = `
-    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ?
+    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ? AND is_deleted = FALSE;
 `;
 
 // 커뮤니티의 최대 인원수를 조회하는 쿼리

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -41,3 +41,9 @@ export const GET_COMMUNITIES = `
     ORDER BY created_at DESC 
     LIMIT ? OFFSET ?;
 `;
+
+// 커뮤니티 ID로 책 id 조회
+export const getCommunityBookID = "SELECT book_id FROM COMMUNITY WHERE community_id = ?;";
+
+// 책 ID로 제목, 표지url 조회
+export const getBookInfo = "SELECT title, image_url FROM BOOK WHERE book_id = ?;";

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -38,6 +38,7 @@ export const COUNT_COMMUNITIES = "SELECT COUNT(*) as count FROM COMMUNITY;";
 //모임 리스트 조회 쿼리 (최신순 정렬)
 export const GET_COMMUNITIES = `
     SELECT * FROM COMMUNITY 
+    WHERE is_deleted = 0
     ORDER BY created_at DESC 
     LIMIT ? OFFSET ?;
 `;
@@ -89,34 +90,18 @@ export const getBookInfo = "SELECT title, image_url FROM BOOK WHERE book_id = ?;
 
 // 제목으로 커뮤니티 검색 (부분 검색 가능)
 export const GET_COMMUNITIES_BY_TITLE_KEYWORD = `
-SELECT 
-    c.community_id,
-    c.user_id,
-    c.book_id,
-    c.address,
-    c.tag,
-    c.capacity,
-    c.created_at,
-    c.updated_at
+SELECT c.*
 FROM COMMUNITY c
 JOIN BOOK b ON c.book_id = b.book_id
-WHERE REPLACE(b.title, ' ', '') LIKE CONCAT('%', REPLACE(?, ' ', ''), '%')
+WHERE REPLACE(b.title, ' ', '') LIKE CONCAT('%', REPLACE(?, ' ', ''), '%') AND is_deleted = 0
 ORDER BY c.created_at DESC;
 `;
 
 
 // 태그로 커뮤니티 검색 (부분 검색 가능)
 export const GET_COMMUNITIES_BY_TAG_KEYWORD = `
-SELECT 
-    c.community_id,
-    c.user_id,
-    c.book_id,
-    c.address,
-    c.tag,
-    c.capacity,
-    c.created_at,
-    c.updated_at  
+SELECT c.*
 FROM COMMUNITY c
-WHERE REPLACE(c.tag, ' ', '') LIKE CONCAT('%', REPLACE(?, ' ', ''), '%')
+WHERE REPLACE(c.tag, ' ', '') LIKE CONCAT('%', REPLACE(?, ' ', ''), '%') AND is_deleted = 0
 ORDER BY c.created_at DESC;
 `;


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #78 

## 📝 작업 내용

1. 전체 모임 리스트 조회
- response 피그마에 맞게 DTO 수정


2. 나의 참여 모임(채팅방) 리스트 조회 
- 최근에 메시지 온 순서대로 우선 정렬
- 안읽음 메시지 개수 response에 추가


3. 모임 생성 : body값에 책 정보와 모임 정보를 입력해 모임 생성
- address 값 대신 enum타입의 location(서울, 부산 등등)을 입력해 모임을 생성하도록 변경된 것 구현함
- 기획 수정에 따라, 모임을 설명하는 content 칼럼이 DB에 추가됨
- book id 유효성 검사해서, DB에 없는 책이면 자동으로 등록하고 모임 생성하도록 수정


4. 모임 검색
- response 수정.
- 책 검색 시, 삭제된 모임은 안뜨도록 sql 쿼리 수정
- 서비스 및 컨트롤러 정리. : 다른 조회 로직들과 동일하게 result에 검색 결과 담아 반환. (actualSize변수 필요없음)


### 📸 스크린샷 (선택)

안읽음 메시지 개수 카운트하는 로직
1) 가입 이후 안읽은 메시지들이 오는 경우
2) 마지막으로 채팅방 들어가 읽은 이후 메시지가 새로 온 경우
위의 두 가지를 고려해, 모임 가입시간과 read_status를 비교해 더 큰 값을 기준으로 사용했습니다.
![image](https://github.com/user-attachments/assets/d5ec721d-12f3-4b8c-b496-7e5db377c614)


## 💬 리뷰 요구사항(선택)

 모임 생성, 모임 검색, 전체 모임 조회, 나의 모임 리스트 4가지 api 테스트해보시면 됩니다 !

+ for문 모두 제거했습니다 !