### PR TITLE
✨ [FEAT] #100: 책 검색시 미리보기용 검색일 경우 최근 검색어에 저장되지 않도록 수정

### DIFF
--- a/src/book/book.controller.js
+++ b/src/book/book.controller.js
@@ -43,14 +43,14 @@ export const getUserRecentBook = async (req, res, next) => {
 
 // 책 검색
 export const searchBook = async (req, res, next) => {
-    let { page=1, size=50, keyword } = req.query;
+    let { page=1, size=50, keyword, preview } = req.query;
     const userId = req.user_id;
     if(!keyword) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
     keyword = keyword.trim();
-    const book = await searchBookService(userId, keyword, parseInt(page), parseInt(size));
+    const book = await searchBookService(userId, keyword, preview === 'true', parseInt(page), parseInt(size));
 
     res.send(response(status.SUCCESS, book.data, book.pageInfo));
 };

--- a/src/book/book.service.js
+++ b/src/book/book.service.js
@@ -58,7 +58,7 @@ export const updateBookIsRead = async (book, cid, userId) => {
     }
 };
 
-export const searchBookService = async (userId, keyword, page, size) => {
+export const searchBookService = async (userId, keyword, preview, page, size) => {
     const BASE_URL = `http://www.aladin.co.kr/ttb/api/ItemSearch.aspx?ttbkey=${process.env.TTB_KEY}&output=js&Version=20131101`;
 
     // 전체 몰 검색
@@ -76,8 +76,8 @@ export const searchBookService = async (userId, keyword, page, size) => {
     const hasNext = bookList.length > size;
     if(hasNext) bookList.pop();
 
-    // 검색어 저장 - 회원인 경우
-    if(!userId) {
+    // 검색어 저장 : 회원이거나 미리보기가 아닌 경우에만 저장
+    if(!userId || preview) {
         return {"data": bookList, "pageInfo": pageInfo(page, bookList.length, hasNext)};
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,6 +3272,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #100 

## 📝 작업 내용
- 프론트와 연동하다보니 책 미리보기 용으로 검색 api를 호출할 때에도 계속해서 검색어가 저장되는 문제가 있어 미리보기용 검색과 실제 검색을 preview 쿼리 스트링 값으로 구분하도록 수정하였습니다. (api 명세서에도 수정사항 반영하였습니다.)

### 📸 스크린샷 (선택)
<img width="1552" alt="스크린샷 2024-08-10 오전 3 33 34" src="https://github.com/user-attachments/assets/292340a0-1866-45d6-b612-4a2cc8e736d5">

## 💬 리뷰 요구사항(선택)
