### PR TITLE
🐛  [BUG] #102: 로그인 안한 회원이 유저 검색시 검색 기록 저장 불가

### DIFF
--- a/src/users/users.service.js
+++ b/src/users/users.service.js
@@ -253,6 +253,10 @@ export const searchUserByKeyword = async (userId, keyword, offset, size) => {
         userSearchResponseDTOList.push(userSearchResponseDTO(paginatedListElement))
     }
 
+    if(!userId){
+        return {userSearchResponseDTOList, totalCount: combinedList.length, currentSize: paginatedList.length}
+    }
+
     const recentSerachId = await getResearchId(userId, keyword);
     if(!recentSerachId) {
         await addSearchDao(userId, keyword);


### PR DESCRIPTION

## #⃣ 연관된 이슈

#102 

## 📝 작업 내용

로그인 안한 회원이 유저 검색시 검색기록 저장 못하게  수정
