### PR TITLE
✨ [FEAT] #112: 책 상세 정보 조회시 책 관련 정보도 같이 넘겨주도록 수정

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -51,6 +51,9 @@ export const status = {
     ACCESS_TOKEN_NOT_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4003", "message": "엑세스 토큰이 만료되지 않았습니다." },
     MISSING_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4004", "message": "헤더에 토큰 값이 존재하지 않습니다." },
     ACCESS_TOKEN_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "엑세스 토큰이 만료되었습니다." },
-    INVALID_REFRESH_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "유효하지 않는 리프레시 토큰입니다." }
+    INVALID_REFRESH_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "유효하지 않는 리프레시 토큰입니다." },
+
+    // book err
+    BOOK_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "BOOK4001", "message": "존재하지 않는 책입니다."},
 
 };

--- a/src/book/book.controller.js
+++ b/src/book/book.controller.js
@@ -1,6 +1,6 @@
 import { response } from "../../config/response.js";
 import { status } from "../../config/response.status.js";
-import { getBookDetailInfoByISBN, updateBookIsRead, findUserRecentBook, searchBookService, createBookSearchService, getBookDetailInfoById, createBook } from "./book.service.js";
+import * as service from "./book.service.js";
 import { pageInfo } from "../../config/pageInfo.js";
 import { BaseError } from "../../config/error.js";
 
@@ -15,10 +15,10 @@ export const getBookDetail = async (req, res, next) => {
     }
 
     if(isBookId === 'true') {
-        const result = await getBookDetailInfoById(parseInt(id), parseInt(page), parseInt(size), userId);
+        const result = await service.getBookDetailInfoById(parseInt(id), parseInt(page), parseInt(size), userId);
         return res.send(response(status.SUCCESS, result.data, result.pageInfo));
     } else {
-        const result = await getBookDetailInfoByISBN(id, parseInt(page), parseInt(size), userId);
+        const result = await service.getBookDetailInfoByISBN(id, parseInt(page), parseInt(size), userId);
         return res.send(response(status.SUCCESS, result.data, result.pageInfo));
     }
 };
@@ -38,10 +38,10 @@ export const updateIsRead = async (req, res, next) => {
     if(isBookId === 'true') {
         bookId = parseInt(id);
     } else {
-        bookId = await createBook(id);
+        bookId = await service.createBook(id);
     }
 
-    res.send(response(await updateBookIsRead(bookId, userId)));
+    res.send(response(await service.updateBookIsRead(bookId, userId)));
 };
 
 // 최근 선택한 책
@@ -51,7 +51,7 @@ export const getUserRecentBook = async (req, res, next) => {
     const offset = (page -1) * size
     const userId = req.user_id;
 
-    const result = await findUserRecentBook(userId, offset, size+1)
+    const result = await service.findUserRecentBook(userId, offset, size+1)
 
     const hasNext = result.length > size;
     if (hasNext) result.pop();
@@ -68,7 +68,7 @@ export const searchBook = async (req, res, next) => {
     }
 
     keyword = keyword.trim();
-    const book = await searchBookService(userId, keyword, preview === 'true', parseInt(page), parseInt(size));
+    const book = await service.searchBookService(userId, keyword, preview === 'true', parseInt(page), parseInt(size));
 
     res.send(response(status.SUCCESS, book.data, book.pageInfo));
 };
@@ -83,7 +83,7 @@ export const createBookSearch = async (req, res, next) => {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
-    await createBookSearchService(ISBN, keyword, userId);
+    await service.createBookSearchService(ISBN, keyword, userId);
 
     res.send(response(status.CREATED));
 };

--- a/src/book/book.controller.js
+++ b/src/book/book.controller.js
@@ -76,14 +76,13 @@ export const searchBook = async (req, res, next) => {
 // 책 검색어 추가
 export const createBookSearch = async (req, res, next) => {
     const userId = req.user_id;
-    const keyword = req.body.keyword;
     const ISBN = req.params.ISBN;
 
-    if(!keyword || !ISBN) {
+    if(!ISBN) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
-    await service.createBookSearchService(ISBN, keyword, userId);
+    await service.createBookSearchService(ISBN, userId);
 
     res.send(response(status.CREATED));
 };

--- a/src/book/book.controller.js
+++ b/src/book/book.controller.js
@@ -1,19 +1,27 @@
 import { response } from "../../config/response.js";
 import { status } from "../../config/response.status.js";
-import { getBookDetailInfo, updateBookIsRead, findUserRecentBook, searchBookService, createBookSearchService } from "./book.service.js";
+import { getBookDetailInfo, updateBookIsRead, findUserRecentBook, searchBookService, createBookSearchService, getBookDetailInfoById } from "./book.service.js";
 import { bookInfoDto } from "./book.dto.js";
 import { pageInfo } from "../../config/pageInfo.js";
 import { BaseError } from "../../config/error.js";
 
 // 책 상세 정보 조회
 export const getBookDetail = async (req, res, next) => {
-    const ISBN = req.params.ISBN;
-    const { page=1, size=10 } = req.query;
+    const id = req.params.id;
+    const { page=1, size=10, isBookId } = req.query;
     const userId = req.user_id;
-    
-    const book = await getBookDetailInfo(ISBN, parseInt(page), parseInt(size), userId);
 
-    res.send(response(status.SUCCESS, book.data, book.pageInfo));
+    if(!id) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+
+    if(isBookId === 'true') {
+        const result = await getBookDetailInfoById(parseInt(id), parseInt(page), parseInt(size), userId);
+        return res.send(response(status.SUCCESS, result.data, result.pageInfo));
+    } else {
+        const result = await getBookDetailInfo(id, parseInt(page), parseInt(size), userId);
+        return res.send(response(status.SUCCESS, result.data, result.pageInfo));
+    }
 };
 
 // 책 읽음 여부 업데이트

--- a/src/book/book.dao.js
+++ b/src/book/book.dao.js
@@ -82,7 +82,7 @@ export const getCategoryIdByAladinCid = async (cid) => {
 }
 
 // 책 생성
-export const createBook = async (book) => {
+export const saveBook = async (book) => {
     const conn = await pool.getConnection();
     try {
         const result = await insertObject(conn, 'BOOK', book);

--- a/src/book/book.dto.js
+++ b/src/book/book.dto.js
@@ -45,9 +45,10 @@ export const bookInfoDto = (data) => {
 export const bookDetailDto = (book, isRead, shorts) => {
     return {
         "book": {
-            "bookId": book.book_id ? book.book_id : null,
+            "bookId": book.book_id,
             "ISBN": book.ISBN,
             "bookCover": book.image_url,
+            "cid": book.cid,
             "bookTitle": book.title,
             "author": book.author,
             "link": book.link,

--- a/src/book/book.dto.js
+++ b/src/book/book.dto.js
@@ -1,7 +1,21 @@
 import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
 
-export const bookListInfoDto = (data) => {
+export const bookSearchResponseDto = (data) => {
+    const books = aladinBookSearchResultDto(data);
+    const result = books.map(book => {
+        return {
+            "ISBN": book.ISBN,
+            "bookCover": book.bookCover,
+            "bookTitle": book.bookTitle,
+            "author": book.author,
+        }
+    })
+
+    return result;
+}
+
+export const aladinBookSearchResultDto = (data) => {
     const mallType = ['BOOK', 'EBOOK', 'FOREIGN'];
     const result = data.map(book => {
         if (!mallType.includes(book.mallType)) {
@@ -28,28 +42,28 @@ export const bookListInfoDto = (data) => {
 };
 
 // 데이터 베이스에 저장할 책 정보
-export const bookInfoDto = (data) => {
-    if (!data || !data.ISBN || !data.bookTitle || !data.cid || !data.bookCover || !data.author || !data.link) {
+export const createBookRequestDto = (data) => {
+    if (!data || !data.ISBN || !data.bookTitle || !data.category_id || !data.bookCover || !data.author || !data.link) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
     return {
         "ISBN": data.ISBN,
         "title": data.bookTitle,
+        "category_id": data.category_id,
         "image_url": data.bookCover,
         "author": data.author,
         "link": data.link
     };
 };
 
-export const bookDetailDto = (book, isRead, shorts) => {
+export const bookDetailResponseDto = (book, isRead, shorts) => {
     return {
         "book": {
             "bookId": book.book_id,
             "ISBN": book.ISBN,
-            "bookCover": book.image_url,
-            "cid": book.cid,
-            "bookTitle": book.title,
+            "bookCover": book.image_url ? book.image_url : book.bookCover,
+            "bookTitle": book.title ? book.title : book.bookTitle,
             "author": book.author,
             "link": book.link,
             "isRead": Boolean(isRead)

--- a/src/book/book.dto.js
+++ b/src/book/book.dto.js
@@ -8,6 +8,10 @@ export const bookListInfoDto = (data) => {
             return null;
         }
 
+        if(book.mallType === 'EBOOK') {
+            book.title = `[EBOOK] ${book.title}`;
+        }
+
         const author = book.author.split(' (지은이)')[0].trim();
 
         return {
@@ -16,14 +20,14 @@ export const bookListInfoDto = (data) => {
             "bookTitle": book.title,
             "author": author,
             "cid": book.categoryId,
-            "mallType": book.mallType,
             "link": book.link
         }
     })
 
-    return result;
+    return result.filter(book => book !== null);
 };
 
+// 데이터 베이스에 저장할 책 정보
 export const bookInfoDto = (data) => {
     if (!data || !data.ISBN || !data.bookTitle || !data.cid || !data.bookCover || !data.author || !data.link) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
@@ -38,14 +42,21 @@ export const bookInfoDto = (data) => {
     };
 };
 
-export const bookDetailDto = (isRead, bookId, data) => {
+export const bookDetailDto = (book, isRead, shorts) => {
     return {
-        "isRead": Boolean(isRead),
-        "bookId": bookId,
-        "shorts": data.map(short => ({
+        "book": {
+            "bookId": book.book_id ? book.book_id : null,
+            "ISBN": book.ISBN,
+            "bookCover": book.image_url,
+            "bookTitle": book.title,
+            "author": book.author,
+            "link": book.link,
+            "isRead": Boolean(isRead)
+        },
+        "shorts": shorts? shorts.map(short => ({
             shortsId: short.shorts_id,
             shortsImg: short.shorts_img,
             phrase: short.phrase
-        }))
+        })) : []
     };
 };

--- a/src/book/book.route.js
+++ b/src/book/book.route.js
@@ -12,7 +12,7 @@ bookRouter.get('', asyncHandler(authJWTNoUserRequired), asyncHandler(searchBook)
 bookRouter.get('/recent', asyncHandler(authJWT), asyncHandler(getUserRecentBook));
 
 // 책 상세 정보 조회 (로그인 선택)
-bookRouter.get('/:ISBN', asyncHandler(authJWTNoUserRequired), asyncHandler(getBookDetail));
+bookRouter.get('/:id', asyncHandler(authJWTNoUserRequired), asyncHandler(getBookDetail));
 
 // 책 검색어 추가
 bookRouter.post('/:ISBN', asyncHandler(authJWTNoUserRequired), asyncHandler(createBookSearch));

--- a/src/book/book.route.js
+++ b/src/book/book.route.js
@@ -14,8 +14,8 @@ bookRouter.get('/recent', asyncHandler(authJWT), asyncHandler(getUserRecentBook)
 // 책 상세 정보 조회 (로그인 선택)
 bookRouter.get('/:id', asyncHandler(authJWTNoUserRequired), asyncHandler(getBookDetail));
 
-// 책 검색어 추가
-bookRouter.post('/:ISBN', asyncHandler(authJWTNoUserRequired), asyncHandler(createBookSearch));
+// 책 검색어 추가 (로그인 필수)
+bookRouter.post('/:ISBN', asyncHandler(authJWT), asyncHandler(createBookSearch));
 
 // 책 읽음 여부 업데이트 (로그인 필수)
-bookRouter.post('/:ISBN/read', asyncHandler(authJWT), asyncHandler(updateIsRead));
+bookRouter.post('/:id/read', asyncHandler(authJWT), asyncHandler(updateIsRead));

--- a/src/book/book.service.js
+++ b/src/book/book.service.js
@@ -144,7 +144,7 @@ export const searchBookService = async (userId, keyword, preview, page, size) =>
     return {"data": bookList, "pageInfo": pageInfo(page, bookList.length, hasNext)};
 };
 
-export const createBookSearchService = async (ISBN, keyword, userId) => {
+export const createBookSearchService = async (ISBN, userId) => {
     let bookId = await dao.getBookIdByISBN(ISBN);
     if(!bookId) {
         const aladinBookInfo = await searchBookByISBN(ISBN);
@@ -159,5 +159,5 @@ export const createBookSearchService = async (ISBN, keyword, userId) => {
         bookId = await dao.saveBook(book);
     }
 
-    await addSearchDao(userId, keyword, bookId);
+    await addSearchDao(userId, null, bookId);
 };

--- a/src/book/book.service.js
+++ b/src/book/book.service.js
@@ -152,10 +152,8 @@ export const createBookSearchService = async (ISBN, userId) => {
         if(!categoryId) {
             throw new BaseError(status.CATEGORY_NOT_FOUND);
         }
-
+        aladinBookInfo.category_id = categoryId;
         const book = createBookRequestDto(aladinBookInfo);
-    
-        book.category_id = categoryId;
         bookId = await dao.saveBook(book);
     }
 

--- a/src/research/research.sql.js
+++ b/src/research/research.sql.js
@@ -15,7 +15,7 @@ DELETE FROM RECENT_SEARCHES
 WHERE recent_searches_id = ?;
 `;
 
-export const getRecentResearchId = "SELECT recent_searches_id FROM RECENT_SEARCHES WHERE user_id = ? AND query = ?;";
+export const getRecentResearchId = "SELECT recent_searches_id FROM RECENT_SEARCHES WHERE user_id = ? AND query = ? AND book_id = null;";
 
 export const SearchUser = `SELECT user_id FROM RECENT_SEARCHES WHERE recent_searches_id = ?;`;
 

--- a/src/shorts/shorts.controller.js
+++ b/src/shorts/shorts.controller.js
@@ -3,10 +3,10 @@ import { status } from "../../config/response.status.js";
 import { response } from "../../config/response.js";
 import { BaseError } from "../../config/error.js";
 import { shortsInfoDto } from "./shorts.dto.js";
-import { bookInfoDto } from "../book/book.dto.js";
 import { addCommentService } from "./shorts.service.js";
 import { likeShortsService } from "./shorts.service.js";
 import { deleteShortsService } from "./shorts.service.js";
+import { createBook } from "../book/book.service.js";
 
 export const getShortsDetail = async (req, res, next) => {
     const { category, keyword, book, user, like, page=1, size=10 } = req.query;
@@ -45,15 +45,21 @@ export const searchShorts = async (req, res, next) => {
 };
 
 export const createShorts = async (req, res, next) => {
-    const book = bookInfoDto(req.body);
+    const ISBN = req.body.ISBN;
     const userId = req.user_id;
+
+    if(!ISBN) {
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
 
     if(!req.file) {
         throw new BaseError(status.INTERNAL_SERVER_ERROR);
     }
+    const bookId = await createBook(req.body.ISBN);
     const shorts = shortsInfoDto(req.body, req.file.location, userId);
+    shorts.book_id = bookId;
 
-    const shortsId = await service.createShorts(book, shorts, req.body.cid);
+    const shortsId = await service.createShorts(shorts);
 
     if(!shortsId) {
         throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/src/shorts/shorts.dto.js
+++ b/src/shorts/shorts.dto.js
@@ -59,7 +59,7 @@ export const shortsInfoDto = (data, imgUrl, userId) => {
         "content": data.content,
         "tag": data.tags,
         "user_id": userId,
-        "phrase_x": data.phraseX,
-        "phrase_y": data.phraseY
+        "phrase_x": parseFloat(data.phraseX),
+        "phrase_y": parseFloat(data.phraseY)
     };
 }

--- a/src/shorts/shorts.service.js
+++ b/src/shorts/shorts.service.js
@@ -1,7 +1,7 @@
 import { BaseError } from "../../config/error.js";
 import { pageInfo } from "../../config/pageInfo.js";
 import { status } from "../../config/response.status.js";
-import { createBook, findBookById, getBookCategory, getBookIdByISBN, getCategoryIdByAladinCid } from "../book/book.dao.js";
+import { saveBook, findBookById, getBookCategory, getBookIdByISBN, getCategoryIdByAladinCid } from "../book/book.dao.js";
 import * as shortsDao from "./shorts.dao.js";
 import * as shortsDetailDao from "./shorts.detail.dao.js";
 import { getSearchShortsListDto, getShortsDetailListDto } from "./shorts.dto.js";
@@ -178,7 +178,7 @@ export const createShorts = async (book, shorts, cid) => {
         }
 
         book.category_id = categoryId;
-        bookId = await createBook(book);
+        bookId = await saveBook(book);
     }
 
     // 쇼츠 정보 글자수 제한 확인

--- a/src/shorts/shorts.service.js
+++ b/src/shorts/shorts.service.js
@@ -166,21 +166,7 @@ export const getShortsDetailUserLike = async (shortsId, userId, page, size) => {
 };
 
 // 쇼츠 생성
-export const createShorts = async (book, shorts, cid) => {
-    // ISBN 값으로 book_id 조회
-    let bookId = await getBookIdByISBN(book.ISBN);
-    
-    // book_id 값이 존재하지 않을 경우 책 정보 생성
-    if(!bookId) {
-        const categoryId = await getCategoryIdByAladinCid(cid);
-        if(!categoryId) {
-            throw new BaseError(status.CATEGORY_NOT_FOUND);
-        }
-
-        book.category_id = categoryId;
-        bookId = await saveBook(book);
-    }
-
+export const createShorts = async (shorts) => {
     // 쇼츠 정보 글자수 제한 확인
     if(shorts.title.length > 30) {
         throw new BaseError(status.SHORTS_TITLE_TOO_LONG);
@@ -202,7 +188,6 @@ export const createShorts = async (book, shorts, cid) => {
 
     // 쇼츠 정보 생성
     shorts.tag = shorts.tag.join("|");
-    shorts.book_id = bookId;
     return await shortsDao.createShorts(shorts);
 };
 

--- a/src/shorts/shorts.service.js
+++ b/src/shorts/shorts.service.js
@@ -1,12 +1,10 @@
 import { BaseError } from "../../config/error.js";
 import { pageInfo } from "../../config/pageInfo.js";
 import { status } from "../../config/response.status.js";
-import { saveBook, findBookById, getBookCategory, getBookIdByISBN, getCategoryIdByAladinCid } from "../book/book.dao.js";
+import { findBookById, getBookCategory } from "../book/book.dao.js";
 import * as shortsDao from "./shorts.dao.js";
 import * as shortsDetailDao from "./shorts.detail.dao.js";
 import { getSearchShortsListDto, getShortsDetailListDto } from "./shorts.dto.js";
-import { addCommentDao, addLikeDao, removeLikeDao, checkLikeDao, getLikeCntDao, checkShortsExistenceDao,
-deleteShortsDao, checkShortsOwnerDao} from "./shorts.dao.js";
 import { addSearchDao, getResearchId, updateSearchDao } from "../research/research.dao.js";
 
 
@@ -197,38 +195,38 @@ export const addCommentService = async (shorts_id, user_id, content) => {
     if (!isShortsExist) {
         throw new BaseError(status.BAD_REQUEST);
     }
-    await addCommentDao(shorts_id, user_id, content);
+    await shortsDao.addCommentDao(shorts_id, user_id, content);
 
 };
 
 export const likeShortsService = async (shorts_id, user_id) => {
-    const exists = await checkShortsExistenceDao(shorts_id);
+    const exists = await shortsDao.checkShortsExistenceDao(shorts_id);
     if (!exists) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
-    const isLiked = await checkLikeDao(shorts_id, user_id);
+    const isLiked = await shortsDao.checkLikeDao(shorts_id, user_id);
 
     if (isLiked) {
-        await removeLikeDao(shorts_id, user_id);
-        return { likeCnt: await getLikeCntDao(shorts_id), action: 'remmoved'};
+        await shortsDao.removeLikeDao(shorts_id, user_id);
+        return { likeCnt: await shortsDao.getLikeCntDao(shorts_id), action: 'remmoved'};
     } else {
-        await addLikeDao(shorts_id, user_id);
-        return { likeCnt: await getLikeCntDao(shorts_id), action: 'added'};
+        await shortsDao.addLikeDao(shorts_id, user_id);
+        return { likeCnt: await shortsDao.getLikeCntDao(shorts_id), action: 'added'};
     }
 
 };
 
 export const deleteShortsService = async (user_id, shorts_id) => {
-    const exists = await checkShortsExistenceDao(shorts_id);
+    const exists = await shortsDao.checkShortsExistenceDao(shorts_id);
     if (!exists) {
         throw new BaseError(status.SHORTS_NOT_FOUND);
     }
 
-    const owner = await checkShortsOwnerDao(shorts_id);
+    const owner = await shortsDao.checkShortsOwnerDao(shorts_id);
     if (owner !== user_id) {
         throw new BaseError(status.UNAUTHORIZED);
     }
 
-    await deleteShortsDao(shorts_id);
+    await shortsDao.deleteShortsDao(shorts_id);
 };


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #112 

## 📝 작업 내용
#### 테스트 돌려보실 때 postman의 책 관련 api들(알라딘 api 제외)과 쇼츠 생성 테스트 해보시면 됩니다!
- 기존 방식은 프론트에서 알라딘 api를 연결하여 책 정보를 갖고오는 방식이었는데 서버에서 알라딘 api를 연결하며 방식이 수정되어 책 정보도 함께 넘어가도록 수정하였습니다.
- isBookId 쿼리스트링 값으로 조회 방식이 ISBN으로 조회하는지 bookId값으로 조회하는지 구분하도록 수정하였습니다. (controller에서 분기)
- ISBN으로 조회할 경우 데이터베이스에 저장된 bookId가 있으면 bookId값 조회 서비스로직을 타도록 설정하였습니다. (service로직 재사용)
- 만약 데이터베이스에 저장되지 않은 책 정보의 경우 알라딘 api를 거쳐 책 정보가 반환되도록 구성하였습니다. (service에 알라딘 api 호출하는 함수 정의)
- 책 읽음 여부를 업데이트 하는 경우에도 책 ID 값을 알고 있으면 해당 값으로 업데이트 되도록 수정하였습니다.
- 책을 저장해야 하는 경우 저장되는 책 데이터의 일관성을 위해 기존 프론트에서 책 정보를 입력해서 저장하는 방식에서 ISBN 값만 넘겨주면 알라딘 아이템 검색 api를 통해 데이터를 받아와 저장하도록 수정하였습니다.

### 📸 스크린샷 (선택)
<img width="1552" alt="스크린샷 2024-08-11 오후 11 23 52" src="https://github.com/user-attachments/assets/9e633f87-ca37-4ff7-a250-4c0d33a2a778">

<img width="1552" alt="스크린샷 2024-08-11 오후 11 25 17" src="https://github.com/user-attachments/assets/d11e0e6b-7157-45ab-ac41-feb1c2a7dfcb">

## 💬 리뷰 요구사항(선택)

