### PR TITLE
✨[FEAT] #107: 커뮤니티 전반적인 수정+커뮤니티 상세정보 조회+채팅방 조회+약속설정

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -19,13 +19,13 @@ export const status = {
   // community arr
   COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY4001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
   INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
-  COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
-  ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
+  COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
+  ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
   COMMUNITY_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
-  NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, "isSuccess": false, code: "COMMUNITY4006", message: "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
-  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
-  INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4008", message: "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
-  LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4009", message: "방장은 커뮤니티를 탈퇴할 수 없습니다." },
+  NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4006", "message": "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
+  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4007", "message": "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
+  INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4008", "message": "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
+  LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4009", "message": "방장은 커뮤니티를 탈퇴할 수 없습니다." },
 
   // member err
   MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -17,16 +17,15 @@ export const status = {
   PARAMETER_IS_WRONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMON006", "message": "잘못된 파라미터입니다." },
 
   // community arr
-  COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
-  INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
+  COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY4001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
+  INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
   COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
   ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
   COMMUNITY_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
   NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, "isSuccess": false, code: "COMMUNITY4006", message: "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
   CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
-  ALREADY_LEFT_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4008", message: "이미 해당 커뮤니티를 탈퇴하였습니다." },
-  INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4009", message: "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
-  LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4010", message: "방장은 커뮤니티를 탈퇴할 수 없습니다." },
+  INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4008", message: "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
+  LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4009", message: "방장은 커뮤니티를 탈퇴할 수 없습니다." },
 
   // member err
   MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -26,7 +26,7 @@ export const status = {
   CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
   ALREADY_LEFT_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4008", message: "이미 해당 커뮤니티를 탈퇴하였습니다." },
   INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4009", message: "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
-
+  LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4010", message: "방장은 커뮤니티를 탈퇴할 수 없습니다." },
 
   // member err
   MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -2,55 +2,58 @@
 import { StatusCodes } from "http-status-codes";
 
 export const status = {
-    // success
-    SUCCESS: { status: StatusCodes.OK, "isSuccess": true, "code": "2000", "message": "SUCCESS!" },
-    CREATED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "CREATED!" },
-    JOINED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "JOINED!" },
-    NO_CONTENT: { status: StatusCodes.NO_CONTENT, "isSuccess": true, "code": "2040", "message": "NO CONTENT!" },
+  // success
+  SUCCESS: { status: StatusCodes.OK, "isSuccess": true, "code": "2000", "message": "SUCCESS!" },
+  CREATED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "CREATED!" },
+  JOINED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "JOINED!" },
+  NO_CONTENT: { status: StatusCodes.NO_CONTENT, "isSuccess": true, "code": "2040", "message": "NO CONTENT!" },
 
-    // error
-    INTERNAL_SERVER_ERROR: { status: StatusCodes.INTERNAL_SERVER_ERROR, "isSuccess": false, "code": "COMMON000", "message": "서버 에러, 관리자에게 문의 바랍니다." },
-    BAD_REQUEST: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMON001", "message": "잘못된 요청입니다." },
-    UNAUTHORIZED: { status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "COMMON002", "message": "권한이 잘못되었습니다." },
-    METHOD_NOT_ALLOWED: { status: StatusCodes.METHOD_NOT_ALLOWED, "isSuccess": false, "code": "COMMON003", "message": "지원하지 않는 Http Method 입니다." },
-    FORBIDDEN: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMON004", "message": "금지된 요청입니다." },
-    NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMON005", "message": "페이지를 찾을 수 없습니다." },
-    PARAMETER_IS_WRONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMON006", "message": "잘못된 파라미터입니다." },
+  // error
+  INTERNAL_SERVER_ERROR: { status: StatusCodes.INTERNAL_SERVER_ERROR, "isSuccess": false, "code": "COMMON000", "message": "서버 에러, 관리자에게 문의 바랍니다." },
+  BAD_REQUEST: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMON001", "message": "잘못된 요청입니다." },
+  UNAUTHORIZED: { status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "COMMON002", "message": "권한이 잘못되었습니다." },
+  METHOD_NOT_ALLOWED: { status: StatusCodes.METHOD_NOT_ALLOWED, "isSuccess": false, "code": "COMMON003", "message": "지원하지 않는 Http Method 입니다." },
+  FORBIDDEN: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMON004", "message": "금지된 요청입니다." },
+  NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMON005", "message": "페이지를 찾을 수 없습니다." },
+  PARAMETER_IS_WRONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMON006", "message": "잘못된 파라미터입니다." },
 
-    // community arr
-    COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
-    INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
-    COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
-    ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
-    COMMUNITY_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
+  // community arr
+  COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
+  INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
+  COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
+  ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
+  COMMUNITY_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
+  NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, code: "COMMUNITY4006", message: "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
+  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
+  ALREADY_LEFT_COMMUNITY: { status: StatusCodes.BAD_REQUEST, code: "COMMUNITY4008", message: "이미 해당 커뮤니티를 탈퇴하였습니다." },
 
-    // member err
-    MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },
-    NICKNAME_NOT_EXIST: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4002", "message": "닉네임은 필수입니다." },
-    FOLLOW_EXIST : { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4003", "message": "이미 처리된 팔로우 혹은 본인입니다." },
-    FOLLOW_NOT_FOUND : { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4004", "message": "현재 팔로우 상태가 아닙니다." },
-    DUPLICATE_ACCOUNT : {status: StatusCodes.BAD_REQUEST, "isSuccess" : false, "code" : "MEMBER4005", "message" : "아이디 중복"},
+  // member err
+  MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },
+  NICKNAME_NOT_EXIST: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4002", "message": "닉네임은 필수입니다." },
+  FOLLOW_EXIST: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4003", "message": "이미 처리된 팔로우 혹은 본인입니다." },
+  FOLLOW_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4004", "message": "현재 팔로우 상태가 아닙니다." },
+  DUPLICATE_ACCOUNT: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4005", "message": "아이디 중복" },
 
-    // category err
-    CATEGORY_NOT_FOUND: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4001", "message": "존재하지 않는 카테고리입니다."},
-    CATEGORY_COUNT_IS_WRONG: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4002", "message": "카테고리 개수는 4~8개로 입력해주세요."},
-    CATEGORY_DUPLICATED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4003", "message": "카테고리는 중복되지 않게 선택해주세요."},
+  // category err
+  CATEGORY_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4001", "message": "존재하지 않는 카테고리입니다." },
+  CATEGORY_COUNT_IS_WRONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4002", "message": "카테고리 개수는 4~8개로 입력해주세요." },
+  CATEGORY_DUPLICATED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "CATEGORY4003", "message": "카테고리는 중복되지 않게 선택해주세요." },
 
 
-    // shorts err
-    SHORTS_TAG_COUNT_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4001", "message": "태그는 10개 이내로 입력해주세요." },
-    SHORTS_TAG_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4002", "message": "태그는 10자 이내로 입력해주세요." },
-    SHORTS_TITLE_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4003", "message": "제목은 30자 이내로 입력해주세요." },
-    SHORTS_CONTENT_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4004", "message": "내용은 255자 이내로 입력해주세요." },
-    SHORTS_PHRASE_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4005", "message": "책 구절은 150자 이내로 입력해주세요." },
-    SHORTS_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "SHORTS4006", "message": "존재하지 않는 쇼츠입니다." },
+  // shorts err
+  SHORTS_TAG_COUNT_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4001", "message": "태그는 10개 이내로 입력해주세요." },
+  SHORTS_TAG_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4002", "message": "태그는 10자 이내로 입력해주세요." },
+  SHORTS_TITLE_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4003", "message": "제목은 30자 이내로 입력해주세요." },
+  SHORTS_CONTENT_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4004", "message": "내용은 255자 이내로 입력해주세요." },
+  SHORTS_PHRASE_TOO_LONG: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SHORTS4005", "message": "책 구절은 150자 이내로 입력해주세요." },
+  SHORTS_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "SHORTS4006", "message": "존재하지 않는 쇼츠입니다." },
 
-    // token err
-    NOT_EXISTING_ACCESS_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4001", "message": "존재하지 않는 엑세스 토큰 입니다." },
-    REFRESH_TOKEN_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4002", "message": "만료된 리프레시 토큰 입니다." },
-    ACCESS_TOKEN_NOT_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4003", "message": "엑세스 토큰이 만료되지 않았습니다." },
-    MISSING_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4004", "message": "헤더에 토큰 값이 존재하지 않습니다." },
-    ACCESS_TOKEN_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "엑세스 토큰이 만료되었습니다." },
-    INVALID_REFRESH_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "유효하지 않는 리프레시 토큰입니다." }
+  // token err
+  NOT_EXISTING_ACCESS_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4001", "message": "존재하지 않는 엑세스 토큰 입니다." },
+  REFRESH_TOKEN_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4002", "message": "만료된 리프레시 토큰 입니다." },
+  ACCESS_TOKEN_NOT_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4003", "message": "엑세스 토큰이 만료되지 않았습니다." },
+  MISSING_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4004", "message": "헤더에 토큰 값이 존재하지 않습니다." },
+  ACCESS_TOKEN_EXPIRED: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "엑세스 토큰이 만료되었습니다." },
+  INVALID_REFRESH_TOKEN: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "TOKEN4005", "message": "유효하지 않는 리프레시 토큰입니다." }
 
 };

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -23,7 +23,6 @@ export const status = {
   ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
   COMMUNITY_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
   NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4006", "message": "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
-  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4007", "message": "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
   INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4008", "message": "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
   LEADER_CANNOT_LEAVE:{ status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY4009", "message": "방장은 커뮤니티를 탈퇴할 수 없습니다." },
 

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -5,7 +5,7 @@ export const status = {
   // success
   SUCCESS: { status: StatusCodes.OK, "isSuccess": true, "code": "2000", "message": "SUCCESS!" },
   CREATED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "CREATED!" },
-  JOINED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2010", "message": "JOINED!" },
+  JOINED: { status: StatusCodes.CREATED, "isSuccess": true, "code": "2020", "message": "JOINED!" },
   NO_CONTENT: { status: StatusCodes.NO_CONTENT, "isSuccess": true, "code": "2040", "message": "NO CONTENT!" },
 
   // error
@@ -20,12 +20,14 @@ export const status = {
   // community arr
   COMMUNITY_LIMIT_EXCEEDED: { status: StatusCodes.FORBIDDEN, "isSuccess": false, "code": "COMMUNITY001", "message": "한 사용자가 같은 책으로 5개 이상의 모임을 생성할 수 없습니다." },
   INVALID_CAPACITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "COMMUNITY1002", "message": "커뮤니티의 수용 인원(capacity)은 최대 10명까지 허용됩니다." },
-  COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
-  ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
+  COMMUNITY_FULL: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4003", "message": "참여 인원 초과로 참여하실 수 없습니다." },
+  ALREADY_IN_COMMUNITY: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4004", "message": "이미 이 커뮤니티에 참여 중입니다." },
   COMMUNITY_NOT_FOUND: { status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "COMMUNITY4005", "message": "존재하지 않는 커뮤니티입니다." },
-  NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, code: "COMMUNITY4006", message: "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
-  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST, code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
-  ALREADY_LEFT_COMMUNITY: { status: StatusCodes.BAD_REQUEST, code: "COMMUNITY4008", message: "이미 해당 커뮤니티를 탈퇴하였습니다." },
+  NOT_IN_COMMUNITY: { status: StatusCodes.NOT_FOUND, "isSuccess": false, code: "COMMUNITY4006", message: "사용자가 해당 커뮤니티에 가입되어 있지 않습니다." },
+  CANNOT_LEAVE_OWNED_COMMUNITY: { status: StatusCodes.BAD_REQUEST,"isSuccess": false,  code: "COMMUNITY4007", message: "방장은 커뮤니티를 탈퇴할 수 없습니다. 커뮤니티를 삭제하세요." },
+  ALREADY_LEFT_COMMUNITY: { status: StatusCodes.BAD_REQUEST,"isSuccess": false,  code: "COMMUNITY4008", message: "이미 해당 커뮤니티를 탈퇴하였습니다." },
+  INVALID_MEETING_DATE: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, code: "COMMUNITY4009", message: "미팅시간은 지금으로부터 적어도 30분이 지난 뒤로 설정해주세요." },
+  
 
   // member err
   MEMBER_NOT_FOUND: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "MEMBER4001", "message": "사용자가 없습니다." },

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -110,9 +110,7 @@ export const getChatroomDetailsController = async (req, res, next) => {
     return res.send(response(status.SUCCESS, detailedCommunityDetails));
 };
 
-import asyncHandler from 'express-async-handler';
-
-export const updateMeetingDetailsController = asyncHandler(async (req, res) => {
+export const updateMeetingDetailsController = async (req, res, next) => {
     const { meetingDate, latitude, longitude, address } = req.body;
     const communityId = req.params.communityId;
     const userId = req.user_id;
@@ -135,4 +133,4 @@ export const updateMeetingDetailsController = asyncHandler(async (req, res) => {
 
     // 성공 시 응답
     res.send(response(status.SUCCESS));
-});
+};

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -37,7 +37,7 @@ export const createCommunityController = async (req, res, next) => {
 
 export const deleteCommunityController = async (req, res, next) => {
     const user_id = req.user_id;
-    const community_id = req.params.communityId;
+    const community_id = parseInt(req.params.communityId);
 
     if (!user_id || !community_id) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
@@ -49,7 +49,7 @@ export const deleteCommunityController = async (req, res, next) => {
 
 // 커뮤니티 가입 컨트롤러
 export const joinCommunityController = async (req, res, next) => {
-    const communityId = req.params.communityId;
+    const communityId = parseInt(req.params.communityId);
     const userId = req.user_id;
 
     if (!communityId) {
@@ -71,11 +71,10 @@ export const getCommunitiesController = async (req, res, next) => {
     res.send(response(status.SUCCESS, result.communityList, result.pageInfo))
 };
 
-
 // 커뮤니티 탈퇴
 export const leaveCommunityController = async (req, res, next) => {
     const userId = req.user_id;
-    const communityId = req.params.communityId;
+    const communityId = parseInt(req.params.communityId);
 
     if (!userId || !communityId) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
@@ -87,7 +86,7 @@ export const leaveCommunityController = async (req, res, next) => {
 
 // 커뮤니티 상세정보 조회
 export const getCommunityDetailsController = async (req, res, next) => {
-    const { communityId } = req.params;
+    const communityId = parseInt(req.params.communityId);
     const userId = req.user_id;
 
     const communityDetails = await getCommunityDetailsService(communityId, userId);
@@ -97,7 +96,7 @@ export const getCommunityDetailsController = async (req, res, next) => {
 // 채팅방 상세정보 조회
 export const getChatroomDetailsController = async (req, res, next) => {
     const userId = req.user_id;
-    const { communityId } = req.params;
+    const communityId = parseInt(req.params.communityId);
 
 
     const detailedCommunityDetails = await getChatroomDetailsService(communityId, userId);
@@ -106,7 +105,7 @@ export const getChatroomDetailsController = async (req, res, next) => {
 
 export const updateMeetingDetailsController = async (req, res, next) => {
     const { meetingDate, latitude, longitude, address } = req.body;
-    const communityId = req.params.communityId;
+    const communityId = parseInt(req.params.communityId);
     const userId = req.user_id;
 
     if (!meetingDate || !latitude || !longitude || !address) {

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -1,7 +1,14 @@
 import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
 import { response } from '../../config/response.js';
-import { deleteCommunityService, createCommunityService, joinCommunityService, getCommunitiesService } from './communities.service.js';
+import {
+    deleteCommunityService,
+    createCommunityService,
+    joinCommunityService,
+    getCommunitiesService,
+    leaveCommunityService,
+    getCommunityDetailsService
+} from './communities.service.js';
 
 
 // 커뮤니티 생성
@@ -29,13 +36,13 @@ export const createCommunityController = async (req, res, next) => {
 
 
 export const deleteCommunityController = async (req, res, next) => {
-    const user_id  = req.user_id;
+    const user_id = req.user_id;
     const community_id = req.params.communityId;
 
     if (!user_id || !community_id) {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
-  
+
     await deleteCommunityService(user_id, community_id);
     res.send(response(status.SUCCESS));
 }
@@ -71,3 +78,44 @@ export const getCommunitiesController = async (req, res, next) => {
     });
 };
 
+
+// 커뮤니티 탈퇴 컨트롤러
+export const leaveCommunityController = async (req, res, next) => {
+    try {
+        const userId = req.user_id;
+        const communityId = req.params.communityId;
+
+        if (!userId || !communityId) {
+            throw new BaseError(status.PARAMETER_IS_WRONG);
+        }
+
+        // 커뮤니티 탈퇴 서비스 호출
+        await leaveCommunityService(communityId, userId);
+
+        // 성공 응답 반환
+        return res.send(response(status.SUCCESS));
+    } catch (err) {
+        next(err);
+    }
+};
+
+// 커뮤니티 상세정보를 조회하는 컨트롤러
+export const getCommunityDetailsController = async (req, res, next) => {
+    const { communityId } = req.params;
+
+    try {
+        // 서비스 계층을 호출하여 비즈니스 로직을 처리
+        const communityDetails = await getCommunityDetailsService(communityId);
+
+        return res.status(200).json({
+            status: 'success',
+            data: communityDetails
+        });
+    } catch (error) {
+        if (error instanceof BaseError) {
+            return next(error);
+        }
+        console.error(error);
+        return next(new BaseError(status.INTERNAL_SERVER_ERROR));
+    }
+};

--- a/src/communities/communities.controllers.js
+++ b/src/communities/communities.controllers.js
@@ -113,9 +113,6 @@ export const updateMeetingDetailsController = async (req, res, next) => {
         throw new BaseError(status.PARAMETER_IS_WRONG);
     }
 
-    console.log('Received request to update meeting details:', { communityId, meetingDate, latitude, longitude, address, userId });
-
-    // 서비스 호출
     await updateMeetingDetailsService(
         communityId,
         meetingDate,
@@ -125,7 +122,6 @@ export const updateMeetingDetailsController = async (req, res, next) => {
         userId
     );
 
-    // 성공 시 응답
     res.send(response(status.SUCCESS));
 };
 

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -15,7 +15,6 @@ import {
     GET_CHATROOM_MEMBERS,
     SET_MEETING_DETAILS,
     GET_COMMUNITY_UPDATED_AT,
-    UPDATE_COMMUNITY_CAPACITY,
     COUNT_COMMUNITIES,
     GET_COMMUNITIES,
     GET_COMMUNITIES_BY_TAG_KEYWORD,
@@ -109,7 +108,6 @@ export const leaveCommunityDao = async (communityId, userId) => {
     const conn = await pool.getConnection();
     try {
         await conn.query(LEAVE_COMMUNITY, [communityId, userId]);
-        await conn.query(UPDATE_COMMUNITY_CAPACITY, [communityId, communityId]);
     } finally {
         if (conn) conn.release();
     }

--- a/src/communities/communities.dao.js
+++ b/src/communities/communities.dao.js
@@ -119,7 +119,7 @@ export const leaveCommunityDao = async (communityId, userId) => {
 export const checkUserInCommunity = async (communityId, userId) => {
     const conn = await pool.getConnection();
     try {
-        const [rows] = await conn.query(CHECK_USER_IN_COMMUNITY, [communityId, userId])
+        const [rows] = await conn.query(CHECK_USER_IN_COMMUNITY, [communityId, userId]);
         // 유저가 존재하지 않으면 null, 존재하면 is_deleted 상태 반환
         return rows.length > 0 ? rows[0].is_deleted : null;
     } finally {

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -10,3 +10,26 @@ export const getCommunitiesDto = (data) => {
         updatedAt: community.updated_at
     }));
 };
+
+export const getCommunityDetailsDto = (data) => {
+    const community = data[0];  // 단일 커뮤니티 상세정보이므로 배열의 첫 번째 요소 사용
+    return {
+        communityId: community.community_id,
+        address: community.address,
+        tags: community.tag ? community.tag.split('|') : [],
+        capacity: community.capacity,
+        createdAt: community.created_at,
+        updatedAt: community.updated_at,
+        book: {
+            bookId: community.book_id,
+            title: community.title,
+            author: community.author,
+            imageUrl: community.book_image
+        },
+        leader: {
+            userId: community.user_id,
+            account: community.leader_account,
+            nickname: community.leader_nickname
+        }
+    };
+};

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -27,7 +27,6 @@ export const getCommunityDetailsDto = (data, isParticipating) => {
         },
         location: community.location,
         createdAt: community.created_at,
-        updatedAt: community.updated_at,
         content: community.content,
         tags: community.tag ? community.tag.split('|') : [],
         capacity: community.capacity,

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -47,7 +47,8 @@ export const getChatroomDetailsDto = (data, members, currentUserId) => {
         },
         meetingDate: community.meeting_date,
         members: members.map(member => ({
-            profileImage: member.profile_image_url,
+            userId: member.user_id,
+            profileImage: member.image_url,
             nickname: member.nickname,
             isMine: member.user_id === currentUserId
         }))

--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -10,26 +10,46 @@ export const getCommunitiesDto = (data) => {
         updatedAt: community.updated_at
     }));
 };
-
-export const getCommunityDetailsDto = (data) => {
-    const community = data[0];  // 단일 커뮤니티 상세정보이므로 배열의 첫 번째 요소 사용
+export const getCommunityDetailsDto = (data, isParticipating) => {
+    const community = data[0];  
     return {
-        communityId: community.community_id,
-        address: community.address,
-        tags: community.tag ? community.tag.split('|') : [],
-        capacity: community.capacity,
-        createdAt: community.created_at,
-        updatedAt: community.updated_at,
         book: {
-            bookId: community.book_id,
             title: community.title,
             author: community.author,
             imageUrl: community.book_image
         },
         leader: {
-            userId: community.user_id,
+            imageUrl: community.leader_image,
             account: community.leader_account,
-            nickname: community.leader_nickname
-        }
+            nickname: community.leader_nickname,
+            userId: community.leader_id
+        },
+        location: community.location,
+        createdAt: community.created_at,
+        updatedAt: community.updated_at,
+        content: community.content,
+        tags: community.tag ? community.tag.split('|') : [],
+        capacity: community.capacity,
+        currentMembers: community.member_count,
+        isParticipating 
+    };
+};
+
+
+export const getChatroomDetailsDto = (data, members, currentUserId) => {
+    const community = data[0];
+    return {
+        title: community.title,
+        tags: community.tag ? community.tag.split('|') : [],
+        where: {
+            position: community.position,
+            address: community.address
+        },
+        meetingDate: community.meeting_date,
+        members: members.map(member => ({
+            profileImage: member.profile_image_url,
+            nickname: member.nickname,
+            isMine: member.user_id === currentUserId
+        }))
     };
 };

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -1,6 +1,13 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { deleteCommunityController, createCommunityController,joinCommunityController,getCommunitiesController } from './communities.controllers.js';
+import {
+    deleteCommunityController,
+    createCommunityController,
+    joinCommunityController,
+    getCommunitiesController,
+    leaveCommunityController,
+    getCommunityDetailsController
+} from './communities.controllers.js';
 import { authJWT } from '../jwt/authJWT.js';
 
 export const communitiesRouter = express.Router();
@@ -8,7 +15,6 @@ export const communitiesRouter = express.Router();
 communitiesRouter.get('/', asyncHandler(getCommunitiesController));
 communitiesRouter.post('/', asyncHandler(authJWT), asyncHandler(createCommunityController));
 communitiesRouter.post('/:communityId', asyncHandler(authJWT), asyncHandler(joinCommunityController));
-
-
 communitiesRouter.delete('/:communityId', asyncHandler(authJWT), asyncHandler(deleteCommunityController));
-
+communitiesRouter.delete('/:communityId/leave', asyncHandler(authJWT), asyncHandler(leaveCommunityController));
+communitiesRouter.get('/:communityId', asyncHandler(getCommunityDetailsController));

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -6,9 +6,11 @@ import {
     joinCommunityController,
     getCommunitiesController,
     leaveCommunityController,
-    getCommunityDetailsController
+    getCommunityDetailsController,
+    getChatroomDetailsController,
+    updateMeetingDetailsController
 } from './communities.controllers.js';
-import { authJWT } from '../jwt/authJWT.js';
+import { authJWT, authJWTNoUserRequired } from '../jwt/authJWT.js';
 
 export const communitiesRouter = express.Router();
 
@@ -17,4 +19,7 @@ communitiesRouter.post('/', asyncHandler(authJWT), asyncHandler(createCommunityC
 communitiesRouter.post('/:communityId', asyncHandler(authJWT), asyncHandler(joinCommunityController));
 communitiesRouter.delete('/:communityId', asyncHandler(authJWT), asyncHandler(deleteCommunityController));
 communitiesRouter.delete('/:communityId/leave', asyncHandler(authJWT), asyncHandler(leaveCommunityController));
-communitiesRouter.get('/:communityId', asyncHandler(getCommunityDetailsController));
+communitiesRouter.get('/:communityId', asyncHandler(authJWTNoUserRequired), asyncHandler(getCommunityDetailsController));
+communitiesRouter.get('/:communityId/details', asyncHandler(authJWT), asyncHandler(getChatroomDetailsController));
+communitiesRouter.patch('/:communityId/details', asyncHandler(authJWT), updateMeetingDetailsController);
+

--- a/src/communities/communities.route.js
+++ b/src/communities/communities.route.js
@@ -21,5 +21,5 @@ communitiesRouter.delete('/:communityId', asyncHandler(authJWT), asyncHandler(de
 communitiesRouter.delete('/:communityId/leave', asyncHandler(authJWT), asyncHandler(leaveCommunityController));
 communitiesRouter.get('/:communityId', asyncHandler(authJWTNoUserRequired), asyncHandler(getCommunityDetailsController));
 communitiesRouter.get('/:communityId/details', asyncHandler(authJWT), asyncHandler(getChatroomDetailsController));
-communitiesRouter.patch('/:communityId/details', asyncHandler(authJWT), updateMeetingDetailsController);
+communitiesRouter.patch('/:communityId/details', asyncHandler(authJWT), asyncHandler(updateMeetingDetailsController));
 

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -143,7 +143,6 @@ export const getCommunityDetailsService = async (communityId, userId) => {
     return getCommunityDetailsDto(communityData, isUserParticipating);
 };
 
-// 채팅방 상세정보를 가져오는 서비스 함수
 export const getChatroomDetailsService = async (communityId, currentUserId) => {
     // 유저가 커뮤니티에 속해 있는지 확인
     const userStatus = await checkUserInCommunity(communityId, currentUserId);
@@ -153,13 +152,17 @@ export const getChatroomDetailsService = async (communityId, currentUserId) => {
         throw new BaseError(status.UNAUTHORIZED);
     }
 
-    const isParticipating = userId ? await checkUserParticipationInCommunityDao(communityId, userId) : false;
+    // 유저가 커뮤니티에 참여하고 있는지 확인
+    const isParticipating = currentUserId ? await checkUserParticipationInCommunityDao(communityId, currentUserId) : false;
 
+    // 커뮤니티 데이터 가져오기
+    const { communityData, membersData } = await getChatroomDetailsDao(communityId);
     if (!communityData || communityData.length === 0) {
         throw new BaseError(status.NOT_FOUND);
     }
 
-    return getCommunityDetailsDto(communityData, isParticipating);
+    // DTO 반환
+    return getChatroomDetailsDto(communityData, membersData, currentUserId);
 };
 
 

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -128,14 +128,19 @@ export const leaveCommunityService = async (communityId, userId) => {
 };
 
 // 커뮤니티 상세정보를 가져오는 서비스 함수
-export const getCommunityDetailsService = async (communityId) => {
+export const getCommunityDetailsService = async (communityId, userId) => {
     const communityData = await getCommunityDetailsDao(communityId);
+    let isUserParticipating = false;
+
 
     if (!communityData || communityData.length === 0) {
         throw new BaseError(status.COMMUNITY_NOT_FOUND);
     }
-    const isUserParticipating = await checkUserParticipationInCommunityDao(communityId, userId);
-    return getCommunityDetailsDto(communityData);
+
+    if(userId !== null) {
+        isUserParticipating = await checkUserParticipationInCommunityDao(communityId, userId);
+    }
+    return getCommunityDetailsDto(communityData, isUserParticipating);
 };
 
 // 채팅방 상세정보를 가져오는 서비스 함수

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -1,15 +1,20 @@
 import { BaseError } from '../../config/error.js';
 import { status } from '../../config/response.status.js';
-import { deleteCommunityDao, 
-         checkCommunityExistenceDao, 
-         checkCommunityOwnerDao,
-         getCommunities, 
-         createCommunityWithCheck, 
-         getCommunityCurrentCount, 
-         getCommunityCapacity, 
-         isUserAlreadyInCommunity, 
-         joinCommunity } from './communities.dao.js';
-import { getCommunitiesDto } from './communities.dto.js';
+import {
+    deleteCommunityDao,
+    checkCommunityExistenceDao,
+    checkCommunityOwnerDao,
+    getCommunities,
+    createCommunityWithCheck,
+    getCommunityCurrentCountDao,
+    getCommunityCapacityDao,
+    joinCommunity,
+    checkUserInCommunity,
+    rejoinCommunity,
+    leaveCommunityDao,
+    getCommunityDetailsDao
+} from './communities.dao.js';
+import { getCommunitiesDto,getCommunityDetailsDto } from './communities.dto.js';
 import { pageInfo } from '../../config/pageInfo.js';
 
 
@@ -44,25 +49,31 @@ export const createCommunityService = async (userId, bookId, address, tag, capac
     await createCommunityWithCheck(userId, bookId, address, tag, capacity);
 };
 
-// 커뮤니티 가입 서비스
+//커뮤니티 가입 서비스스
 export const joinCommunityService = async (communityId, userId) => { 
-    const userInCommunity = await isUserAlreadyInCommunity(communityId, userId); 
-    if (userInCommunity) {
+    // 유저가 커뮤니티에 이미 존재하는지 확인하고 is_deleted 상태 반환
+    const userStatus = await checkUserInCommunity(communityId, userId);
+
+    if (userStatus === null) {
+        // 디비에 유저 정보가 없으면 새로 가입 처리
+        await joinCommunity(communityId, userId);
+    } else if (userStatus === 1) {
+        // 유저가 탈퇴한 경우, 재가입 처리
+        await rejoinCommunity(communityId, userId);
+    } else {
+        // 유저가 이미 가입되어 있는 경우 오류 발생
         throw new BaseError(status.ALREADY_IN_COMMUNITY);
     }
 
-    const currentCount = await getCommunityCurrentCount(communityId);
-    const capacity = await getCommunityCapacity(communityId);
+    // 커뮤니티의 현재 인원수 및 최대 인원수 조회
+    const currentCount = await getCommunityCurrentCountDao(communityId);
+    const capacity = await getCommunityCapacityDao(communityId);
 
+    // 현재 인원수가 최대 인원수를 초과하면 오류 발생
     if (currentCount >= capacity) {
         throw new BaseError(status.COMMUNITY_FULL);
     }
-
-    await joinCommunity(communityId, userId);
 };
-
-
-
 
 // 전체 모임 리스트 조회
 export const getCommunitiesService = async (page, size) => {
@@ -87,10 +98,46 @@ export const deleteCommunityService = async (user_id, community_id) => {
     }
 
     const owner = await checkCommunityOwnerDao(community_id);
-    if ( owner !== user_id) {
+    if (owner !== user_id) {
         throw new BaseError(status.UNAUTHORIZED);
     }
 
     await deleteCommunityDao(community_id);
 };
 
+
+// 커뮤니티 탈퇴 서비스
+export const leaveCommunityService = async (communityId, userId) => {
+    // 유저가 커뮤니티에 존재하는지 확인
+    const userStatus = await checkUserInCommunity(communityId, userId);
+
+    if (userStatus === null) {
+        // 유저가 커뮤니티에 가입되어 있지 않은 경우
+        throw new BaseError(status.NOT_IN_COMMUNITY);
+    } else if (userStatus === 1) {
+        // 유저가 이미 탈퇴한 경우
+        throw new BaseError(status.ALREADY_LEFT_COMMUNITY);
+    }
+
+    // 유저 탈퇴 처리 (소프트 딜리트 및 삭제 시간 기록)
+    await leaveCommunityDao(communityId, userId);
+};
+
+// 커뮤니티 상세정보를 가져오는 서비스 함수
+export const getCommunityDetailsService = async (communityId) => {
+    try {
+        // DAO를 통해 데이터베이스에서 커뮤니티 정보를 가져옴
+        const communityData = await getCommunityDetailsDao(communityId);
+
+        // 커뮤니티 정보가 없으면 에러를 던짐
+        if (!communityData || communityData.length === 0) {
+            throw new BaseError(status.COMMUNITY_NOT_FOUND);
+        }
+
+        // DTO를 통해 데이터를 변환하여 반환
+        return getCommunityDetailsDto(communityData);
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};

--- a/src/communities/communities.service.js
+++ b/src/communities/communities.service.js
@@ -145,11 +145,7 @@ export const leaveCommunityService = async (communityId, userId) => {
     // 유저가 커뮤니티에 존재하는지 확인
     const userStatus = await checkUserInCommunity(communityId, userId);
 
-    if (userStatus === null) {
-        // 유저가 커뮤니티에 가입되어 있지 않은 경우
-        throw new BaseError(status.NOT_IN_COMMUNITY);
-    } else if (userStatus) {
-        // 유저가 이미 탈퇴한 경우
+    if (userStatus === null || userStatus) {
         throw new BaseError(status.NOT_IN_COMMUNITY);
     }
 

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -170,3 +170,14 @@ WHERE REPLACE(c.tag, ' ', '') LIKE CONCAT('%', REPLACE(?, ' ', ''), '%')
 ORDER BY c.created_at DESC;
 `;
 
+export const CHECK_IF_LEADER = `
+    SELECT role 
+    FROM COMMUNITY_USERS 
+    WHERE community_id = ? AND user_id = ? AND is_deleted = 0
+`;
+
+export const CHECK_COMMUNITY_EXISTENCE = `
+    SELECT COUNT(*) as count 
+    FROM COMMUNITY 
+    WHERE community_id = ? AND is_deleted = 0
+`;

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -6,7 +6,7 @@ export const GET_COMMUNITY_CAPACITY = `
 // 커뮤니티에 재가입하는 쿼리
 export const REJOIN_COMMUNITY = `
     UPDATE COMMUNITY_USERS 
-    SET is_deleted = 0, updated_at = NOW(), deleted_at = NULL 
+    SET is_deleted = 0, deleted_at = NULL 
     WHERE community_id = ? AND user_id = ?
 `;
 
@@ -18,7 +18,7 @@ export const JOIN_COMMUNITY = `
 
 // 커뮤니티 현재 참여자 수 조회 쿼리 (탈퇴하지 않은 유저만 카운트)
 export const GET_COMMUNITY_CURRENT_COUNT = `
-    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ? AND is_deleted = 0
+    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ? AND is_deleted = false
 `;
 
 // 방장 추가 쿼리
@@ -47,7 +47,7 @@ export const GET_COMMUNITIES = `
 // 커뮤니티 탈퇴(소프트 딜리트) 쿼리
 export const LEAVE_COMMUNITY = `
     UPDATE COMMUNITY_USERS 
-    SET is_deleted = 1, deleted_at = NOW(), updated_at = NOW() 
+    SET is_deleted = 1, deleted_at = NOW(), 
     WHERE community_id = ? AND user_id = ?
 `;
 
@@ -65,7 +65,6 @@ export const GET_COMMUNITY_DETAILS = `
         c.tag,
         c.capacity,
         c.created_at,
-        c.updated_at,
         c.content,
         b.title,
         b.author,
@@ -123,7 +122,6 @@ export const SET_MEETING_DETAILS = `
     WHERE 
         c.community_id = ? 
         AND cu.user_id = ? 
-        AND cu.role = 'admin' 
         AND c.is_deleted = 0;
 `;
 export const GET_COMMUNITY_UPDATED_AT = `
@@ -180,4 +178,16 @@ export const CHECK_COMMUNITY_EXISTENCE = `
     SELECT COUNT(*) as count 
     FROM COMMUNITY 
     WHERE community_id = ? AND is_deleted = 0
+`;
+
+export const UPDATE_COMMUNITY_CAPACITY = `
+    UPDATE COMMUNITY c
+    JOIN (
+        SELECT community_id, COUNT(*) AS user_count
+        FROM COMMUNITY_USERS
+        WHERE community_id = ? AND is_deleted = 0
+        GROUP BY community_id
+    ) cu ON c.community_id = cu.community_id
+    SET c.capacity = cu.user_count
+    WHERE c.community_id = ?;
 `;

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -62,19 +62,20 @@ export const CHECK_USER_IN_COMMUNITY = `
 // 커뮤니티 상세정보를 조회하는 쿼리
 export const GET_COMMUNITY_DETAILS = `
     SELECT 
-        c.community_id,
-        c.address,
+        c.location,
         c.tag,
         c.capacity,
         c.created_at,
         c.updated_at,
-        b.book_id,
+        c.content,
         b.title,
         b.author,
         b.image_url AS book_image,
-        u.user_id,
+        u.image_url AS leader_image,
         u.account AS leader_account,
-        u.nickname AS leader_nickname
+        u.user_id AS leader_id,
+        u.nickname AS leader_nickname,
+        (SELECT COUNT(*) FROM COMMUNITY_USERS cm WHERE cm.community_id = c.community_id) AS member_count
     FROM 
         COMMUNITY c
     JOIN 
@@ -83,4 +84,55 @@ export const GET_COMMUNITY_DETAILS = `
         USERS u ON c.user_id = u.user_id
     WHERE 
         c.community_id = ? AND c.is_deleted = 0
+`;
+
+export const GET_CHATROOM_DETAILS = `
+    SELECT 
+        b.title,
+        c.tag,
+        c.position,
+        c.address,
+        c.meeting_date
+    FROM 
+        COMMUNITY c
+    JOIN 
+        BOOK b ON c.book_id = b.book_id
+    WHERE 
+        c.community_id = ? AND c.is_deleted = 0
+`;
+
+export const GET_CHATROOM_MEMBERS = `
+    SELECT 
+        m.user_id,
+        u.image_url,
+        u.nickname
+    FROM 
+        COMMUNITY_USERS m
+    JOIN 
+        USERS u ON m.user_id = u.user_id
+    WHERE 
+        m.community_id = ? AND m.is_deleted = 0
+`;
+
+export const SET_MEETING_DETAILS = `
+    UPDATE COMMUNITY c
+    JOIN COMMUNITY_USERS cu ON c.community_id = cu.community_id
+    SET 
+        c.meeting_date = ?, 
+        c.position = ST_GeomFromText(?),
+        c.address = ?
+    WHERE 
+        c.community_id = ? 
+        AND cu.user_id = ? 
+        AND cu.role = 'admin' 
+        AND c.is_deleted = 0;
+`;
+export const GET_COMMUNITY_UPDATED_AT = `
+SELECT updated_at FROM COMMUNITY WHERE community_id = ?;
+`;
+
+export const CHECK_USER_PARTICIPATION_QUERY = `
+SELECT COUNT(*) AS count
+FROM COMMUNITY_USERS
+WHERE community_id = ? AND user_id = ? AND is_deleted = 0;
 `;

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -1,22 +1,25 @@
-// 커뮤니티의 현재 참여자 수를 조회하는 쿼리
-export const GET_COMMUNITY_CURRENT_COUNT = `
-    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ?
-`;
-
 // 커뮤니티의 최대 인원수를 조회하는 쿼리
 export const GET_COMMUNITY_CAPACITY = `
     SELECT capacity FROM COMMUNITY WHERE community_id = ?
 `;
 
-// 사용자가 이미 커뮤니티에 참여하고 있는지 확인하는 쿼리
-export const IS_USER_ALREADY_IN_COMMUNITY = `
-    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ? AND user_id = ?
+// 커뮤니티에 재가입하는 쿼리
+export const REJOIN_COMMUNITY = `
+    UPDATE COMMUNITY_USERS 
+    SET is_deleted = 0, updated_at = NOW(), deleted_at = NULL 
+    WHERE community_id = ? AND user_id = ?
 `;
 
 // 커뮤니티에 참여하는 쿼리
 export const JOIN_COMMUNITY = `
     INSERT INTO COMMUNITY_USERS (community_id, user_id)
     VALUES (?, ?)
+`;
+
+
+// 커뮤니티 현재 참여자 수 조회 쿼리 (탈퇴하지 않은 유저만 카운트)
+export const GET_COMMUNITY_CURRENT_COUNT = `
+    SELECT COUNT(*) AS count FROM COMMUNITY_USERS WHERE community_id = ? AND is_deleted = 0
 `;
 
 // 방장 추가 쿼리
@@ -40,4 +43,44 @@ export const GET_COMMUNITIES = `
     SELECT * FROM COMMUNITY 
     ORDER BY created_at DESC 
     LIMIT ? OFFSET ?;
+`;
+
+// 커뮤니티 탈퇴(소프트 딜리트) 쿼리
+export const LEAVE_COMMUNITY = `
+    UPDATE COMMUNITY_USERS 
+    SET is_deleted = 1, deleted_at = NOW(), updated_at = NOW() 
+    WHERE community_id = ? AND user_id = ?
+`;
+
+// 유저가 커뮤니티에 존재하는지 확인하고, is_deleted 상태를 반환
+export const CHECK_USER_IN_COMMUNITY = `
+    SELECT is_deleted 
+    FROM COMMUNITY_USERS 
+    WHERE community_id = ? AND user_id = ?
+`;
+
+// 커뮤니티 상세정보를 조회하는 쿼리
+export const GET_COMMUNITY_DETAILS = `
+    SELECT 
+        c.community_id,
+        c.address,
+        c.tag,
+        c.capacity,
+        c.created_at,
+        c.updated_at,
+        b.book_id,
+        b.title,
+        b.author,
+        b.image_url AS book_image,
+        u.user_id,
+        u.account AS leader_account,
+        u.nickname AS leader_nickname
+    FROM 
+        COMMUNITY c
+    JOIN 
+        BOOK b ON c.book_id = b.book_id
+    JOIN 
+        USERS u ON c.user_id = u.user_id
+    WHERE 
+        c.community_id = ? AND c.is_deleted = 0
 `;

--- a/src/communities/communities.sql.js
+++ b/src/communities/communities.sql.js
@@ -47,7 +47,7 @@ export const GET_COMMUNITIES = `
 // 커뮤니티 탈퇴(소프트 딜리트) 쿼리
 export const LEAVE_COMMUNITY = `
     UPDATE COMMUNITY_USERS 
-    SET is_deleted = 1, deleted_at = NOW(), 
+    SET is_deleted = 1, deleted_at = NOW() 
     WHERE community_id = ? AND user_id = ?
 `;
 
@@ -180,14 +180,3 @@ export const CHECK_COMMUNITY_EXISTENCE = `
     WHERE community_id = ? AND is_deleted = 0
 `;
 
-export const UPDATE_COMMUNITY_CAPACITY = `
-    UPDATE COMMUNITY c
-    JOIN (
-        SELECT community_id, COUNT(*) AS user_count
-        FROM COMMUNITY_USERS
-        WHERE community_id = ? AND is_deleted = 0
-        GROUP BY community_id
-    ) cu ON c.community_id = cu.community_id
-    SET c.capacity = cu.user_count
-    WHERE c.community_id = ?;
-`;


### PR DESCRIPTION

## #⃣ 연관된 이슈

> ex) #107

## 📝 작업 내용

1. 커뮤니티 탈퇴 (소프트딜리트)
2. 커뮤니티 탈퇴를 소프트딜리트로 설정함에 따라 커뮤니티 가입 시 재가입의 경우를 고려한 로직 변경
3. 커뮤니티 상세조회(채팅방 들어가기 전 화면)
4. 채팅방 상세조회(피그마에서 채팅방 햄버거바 누르면 나오는 화면)
5. 약속설정(시간 및 장소설정, 업데이트 시간 기준 30분 이상 지난 시간부터 설정 가능, 에러 확인요망)

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 노션의 명세서 참고해서 모든 에러 확인 부탁드립니다!
> 탈퇴 후 재가입의 경우 잘 돌아가는지 확인 부탁드립니다!
