### PR TITLE
🐛 [HOTFIX] : 메인 화면 추천탭 조회시 유저가 선호하는 카테고리의 인기 쇼츠 조회 sql문 수정

### DIFF
--- a/src/home/home.dao.js
+++ b/src/home/home.dao.js
@@ -1,4 +1,5 @@
 import { pool } from "../../config/db.config.js";
+import { POPULARITY_LIKE_CNT } from "../shorts/shorts.service.js";
 import { getShortsByCategory, getAllCategories, getFollowerFeed, getShort, getUserCategories, getUserRecommendedShorts } from "./home.sql.js";
 
 // 카테고리 별 쇼츠 조회
@@ -47,7 +48,7 @@ export const getUserCategoriesById = async(user_id) => {
 export const getRecommendedShorts = async (user_id) => {
     const conn = await pool.getConnection();
     try {
-        const [userRecommendedShorts] = await conn.query(getUserRecommendedShorts, [user_id]);
+        const [userRecommendedShorts] = await conn.query(getUserRecommendedShorts, [POPULARITY_LIKE_CNT, user_id]);
         return userRecommendedShorts;
     } catch (err) {
         console.log(err);

--- a/src/shorts/shorts.detail.dao.js
+++ b/src/shorts/shorts.detail.dao.js
@@ -2,7 +2,7 @@ import { pool } from "../../config/db.config.js";
 import { findFollowStatus } from "../users/users.sql.js";
 import * as sql from "./shorts.detail.sql.js";
 import { POPULARITY_LIKE_CNT } from "./shorts.service.js";
-import { countShortsDetailByBookId, isLikeShorts } from "./shorts.sql.js";
+import { isLikeShorts } from "./shorts.sql.js";
 
 // 쇼츠 ID로 쇼츠 상세 조회
 export const getShortsDetailToShortsId = async (shortsId, userId) => {


### PR DESCRIPTION
## 📝 작업 내용
- 기존 sql문이 유저가 찜한 쇼츠에 없는 카테고리를 선호 카테고리로 선택하였을 때 관련 인기 쇼츠가 안 내려가는 에러가 있어 해당 부분의 sql문을 수정하였습니다.

### 테스트 과정
```sql
-- like_shorts 테이블에 없는 쇼츠와 카테고리 id 조회
SELECT s.shorts_id, b.category_id, COALESCE(likes.like_count, 0) AS like_count FROM SHORTS s
LEFT JOIN BOOK b On s.book_id = b.book_id
LEFT JOIN (
    SELECT shorts_id, COUNT(*) AS like_count
    FROM LIKE_SHORTS
    GROUP BY shorts_id
) likes ON s.shorts_id = likes.shorts_id
WHERE COALESCE(likes.like_count, 0) = 0; -- 좋아요 수 0개인 쇼츠 category_id : 3 or 1 / shorts_id : 140000, 2327, 14000
```
<img width="1440" alt="스크린샷 2024-08-16 오후 5 32 19" src="https://github.com/user-attachments/assets/cd20f965-793b-4d47-a37a-5e883b96ae9a">

```sql
-- user 3이 좋아요 한 카테고리
SELECT c.category_id, c.name FROM CATEGORY c
LEFT JOIN USER_FAVORITE uf ON c.category_id = uf.category_id
WHERE uf.user_id = 3; -- 시, 에세이, 경제/경영, 역사, 과학 (category_id 3 포함되도록 수정)
```
<img width="1440" alt="스크린샷 2024-08-16 오후 5 32 41" src="https://github.com/user-attachments/assets/91abd9ba-e484-4cd6-8055-e10200e93ceb">

```sql
-- 메인화면 카테고리별 추천 쇼츠 랜덤 1개씩 (추천 기준: 좋아요 일정 수 이상 받은 쇼츠)
WITH RankedShorts AS (
    SELECT
        s.shorts_id, s.image_url AS shortsImg, s.phrase, s.title,
        b.author,
        c.name AS category, c.category_id,
        COALESCE(likes.like_count, 0) AS like_count,
        ROW_NUMBER() OVER (PARTITION BY c.category_id ORDER BY RAND()) AS rn
    FROM SHORTS s
    LEFT JOIN BOOK b ON s.book_id = b.book_id
    LEFT JOIN USER_FAVORITE uf ON b.category_id = uf.category_id
    LEFT JOIN CATEGORY c ON uf.category_id = c.category_id
    LEFT JOIN (
        SELECT shorts_id, COUNT(*) AS like_count
        FROM LIKE_SHORTS
        GROUP BY shorts_id
    ) likes ON s.shorts_id = likes.shorts_id
    WHERE COALESCE(likes.like_count, 0) >= 0 AND uf.user_id = 3
)
SELECT
    shorts_id, shortsImg, phrase, title, author, category, like_count
FROM RankedShorts
WHERE rn = 1
ORDER BY category_id; — 140000 나오는지 확인
```
<img width="1440" alt="스크린샷 2024-08-16 오후 5 33 37" src="https://github.com/user-attachments/assets/4669b24c-52da-48bb-97f8-6b4407dd80a0">

```sql
-- 역사 카테고리 중 유저3이 좋아요 누른 쇼츠 없지만 위 쿼리 실행 결과 역사 추천 쇼츠도 조회됨
SELECT ls.like_shorts_id, ls.shorts_id, b.category_id, c.name FROM LIKE_SHORTS ls
LEFT JOIN SHORTS s ON ls.shorts_id = s.shorts_id
LEFT JOIN BOOK b ON s.book_id = b.book_id
LEFT JOIN CATEGORY c ON b.category_id = c.category_id
WHERE ls.user_id = 3 AND c.name = '역사';
```
<img width="1440" alt="스크린샷 2024-08-16 오후 5 34 48" src="https://github.com/user-attachments/assets/3dd873ac-128a-4015-b1c4-057a0c96eb18">

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
