### PR TITLE
🐛  [!HOTFIX] #124: 마이페이지 프로필 조회시 이메일 값 추가 전송

### DIFF
--- a/src/users/users.dto.js
+++ b/src/users/users.dto.js
@@ -6,6 +6,7 @@ export const userInfoResponseDTO = async (userData, isRecentPost, followerNum, f
         "nickname" : userData.nickname,
         "account" : userData.account,
         "comment" : userData.comment,
+        "email" : userData.email,
         "followerNum" : followerNum,
         "followingNum" : followingNum,
         "profileImg" : userData.image_url,


### PR DESCRIPTION

## #⃣ 연관된 이슈

#124 

## 📝 작업 내용

> 마이페이지 프로필 조회시 이메일값도 전송해주기로 했습니다!
프론트측에서 유저 프로필 편집 api 구현시 이메일 값이 나와서 여기서 전달해주면 받아서 사용하기로 했습니다!

### 📸 스크린샷 (선택)

<img width="1082" alt="스크린샷 2024-08-17 오후 9 55 28" src="https://github.com/user-attachments/assets/de30b946-becd-4172-90c6-0b4eb40c2844">

