### PR TITLE
🐛 [!HOTFIX] #140: 메인화면 카테고리탭 조회에서 유저인가 부분 추가 및 쿼리문 수정

### DIFF
--- a/src/home/home.controller.js
+++ b/src/home/home.controller.js
@@ -6,18 +6,11 @@ import { ShortsByCategory, getMainInfo } from "./home.service.js";
 // 카테고리 탭별 숏츠 리스트 조회
 export const getCategoryShorts = async (req, res, next) => {
     const category_name = req.query.category;
-    const page = parseInt(req.query.page) || 1;
-    const size = parseInt(req.query.size) || 20;
-    const offset = (page - 1) * size;
-
     const user_id = req.user_id;
 
-    const result = await ShortsByCategory(category_name, user_id, offset, size+1);
+    const result = await ShortsByCategory(category_name, user_id);
 
-    const hasNext = result.length > size;
-    if (hasNext) result.pop();
-
-    res.send(response(status.SUCCESS, result, pageInfo(page, result.length, hasNext)));
+    res.send(response(status.SUCCESS, result));
 };
 
 // 메인 화면 정보 조회

--- a/src/home/home.controller.js
+++ b/src/home/home.controller.js
@@ -9,7 +9,10 @@ export const getCategoryShorts = async (req, res, next) => {
     const page = parseInt(req.query.page) || 1;
     const size = parseInt(req.query.size) || 20;
     const offset = (page - 1) * size;
-    const result = await ShortsByCategory(category_name, offset, size+1);
+
+    const user_id = req.user_id;
+
+    const result = await ShortsByCategory(category_name, user_id, offset, size+1);
 
     const hasNext = result.length > size;
     if (hasNext) result.pop();
@@ -22,7 +25,7 @@ export const getHomeInfo = async(req, res, next) => {
     const page = parseInt(req.query.page) || 1;
     const size = parseInt(req.query.size) || 20;
     const offset = (page - 1) * size;
-    const user_id = req.user_id;  // TODO: 유저 인가 수정
+    const user_id = req.user_id;
 
     const result = await getMainInfo(user_id, offset, size+1);
 

--- a/src/home/home.dao.js
+++ b/src/home/home.dao.js
@@ -3,10 +3,10 @@ import { POPULARITY_LIKE_CNT } from "../shorts/shorts.service.js";
 import { getShortsByCategory, getAllCategories, getFollowerFeed, getShort, getUserCategories, getUserRecommendedShorts } from "./home.sql.js";
 
 // 카테고리 별 쇼츠 조회
-export const getShortsbyCategory = async (category_id, offset, limit) => {
+export const getShortsbyCategory = async (category_id, user_id, offset, limit) => {
     const conn = await pool.getConnection();
     try {
-        const [categoryShorts] = await conn.query(getShortsByCategory, [category_id, category_id]);
+        const [categoryShorts] = await conn.query(getShortsByCategory, [user_id, category_id, user_id, category_id]);
         return categoryShorts;
     } catch (err) {
         console.log(err);

--- a/src/home/home.dao.js
+++ b/src/home/home.dao.js
@@ -3,10 +3,10 @@ import { POPULARITY_LIKE_CNT } from "../shorts/shorts.service.js";
 import { getShortsByCategory, getAllCategories, getFollowerFeed, getShort, getUserCategories, getUserRecommendedShorts } from "./home.sql.js";
 
 // 카테고리 별 쇼츠 조회
-export const getShortsbyCategory = async (category_id, user_id, offset, limit) => {
+export const getShortsbyCategory = async (category_id, user_id) => {
     const conn = await pool.getConnection();
     try {
-        const [categoryShorts] = await conn.query(getShortsByCategory, [user_id, category_id, user_id, category_id]);
+        const [categoryShorts] = await conn.query(getShortsByCategory, [user_id, category_id, 30, user_id, category_id, 20]);
         return categoryShorts;
     } catch (err) {
         console.log(err);

--- a/src/home/home.dto.js
+++ b/src/home/home.dto.js
@@ -1,9 +1,9 @@
 // 홈에서 카테고리별 숏츠 리스트 조회시 반환값
-export const categoryShortsResponseDTO = (shorts, isRecentPost) => {
+export const categoryShortsResponseDTO = (shorts) => {
     return {
         "userId" : shorts.user_id,
         "profileImg": shorts.profileImg,
-        "nickname": shorts.nickname,
+        "account": shorts.account,
         "shortsId": shorts.shorts_id,
         "bookId": shorts.book_id,
         "shortsImg": shorts.shortsImg,
@@ -37,7 +37,7 @@ export const HomeInfoResponseDTO = (user_id, categories, shorts, feeds) => {
         "feeds": feeds ? feeds.map(feeds => ({
             "user_id": feeds.user_id,
             "profileImg": feeds.profileImg,
-            "nickname": feeds.nickname,
+            "account": shorts.account,
             "shorts_id": feeds.shorts_id,
             "shortsImg": feeds.shortsImg,
             "phrase": feeds.phrase,

--- a/src/home/home.dto.js
+++ b/src/home/home.dto.js
@@ -1,7 +1,8 @@
 // 홈에서 카테고리별 숏츠 리스트 조회시 반환값
-export const categoryShortsResponseDTO = (shorts) => {
+export const categoryShortsResponseDTO = (shorts, isRecentPost) => {
     return {
         "userId" : shorts.user_id,
+        "isRecentPost" : isRecentPost,
         "profileImg": shorts.profileImg,
         "nickname": shorts.nickname,
         "shortsId": shorts.shorts_id,

--- a/src/home/home.dto.js
+++ b/src/home/home.dto.js
@@ -2,7 +2,6 @@
 export const categoryShortsResponseDTO = (shorts, isRecentPost) => {
     return {
         "userId" : shorts.user_id,
-        "isRecentPost" : isRecentPost,
         "profileImg": shorts.profileImg,
         "nickname": shorts.nickname,
         "shortsId": shorts.shorts_id,

--- a/src/home/home.route.js
+++ b/src/home/home.route.js
@@ -5,7 +5,7 @@ import { authJWTNoUserRequired } from '../jwt/authJWT.js';
 
 export const homeRouter = express.Router();
 
-homeRouter.get('/categories', asyncHandler(getCategoryShorts));
+homeRouter.get('/categories', asyncHandler(authJWTNoUserRequired), asyncHandler(getCategoryShorts));
 
 // 메인 화면 정보 조회 (맞춤 탭)
 homeRouter.get('/', asyncHandler(authJWTNoUserRequired), asyncHandler(getHomeInfo));

--- a/src/home/home.service.js
+++ b/src/home/home.service.js
@@ -3,7 +3,7 @@ import { BaseError } from "../../config/error.js";
 import { categoryShortsResponseDTO, HomeInfoResponseDTO } from "./home.dto.js";
 import { getShortsbyCategory, getAllCategory, getUserCategoriesById,getFollowersFeeds, getRecommendedShorts} from "./home.dao.js";
 import { getCategoryIdByName } from "../book/book.dao.js";
-import * as dao from "../users/users.dao.js";
+
 
 // 카테고리별 쇼츠 리스트 조회 로직
 export const ShortsByCategory = async (category_name, user_id, offset, limit) => {
@@ -15,8 +15,7 @@ export const ShortsByCategory = async (category_name, user_id, offset, limit) =>
 
 
     for (const shorts of categoryShorts) {
-        let isRecentPost = await dao.hasRecentPostForUser(shorts.user_id);
-        let result = categoryShortsResponseDTO(shorts, isRecentPost);
+        let result = categoryShortsResponseDTO(shorts);
         categoryShortsDTOList.push(result);
     }
 

--- a/src/home/home.service.js
+++ b/src/home/home.service.js
@@ -6,10 +6,10 @@ import { getCategoryIdByName } from "../book/book.dao.js";
 
 
 // 카테고리별 쇼츠 리스트 조회 로직
-export const ShortsByCategory = async (category_name, user_id, offset, limit) => {
+export const ShortsByCategory = async (category_name, user_id) => {
 
     const category_id = await getCategoryIdByName(category_name);
-    const categoryShorts = await getShortsbyCategory(category_id, user_id, offset, limit);
+    const categoryShorts = await getShortsbyCategory(category_id, user_id);
     const categoryShortsDTOList = [];
 
 

--- a/src/home/home.service.js
+++ b/src/home/home.service.js
@@ -3,6 +3,7 @@ import { BaseError } from "../../config/error.js";
 import { categoryShortsResponseDTO, HomeInfoResponseDTO } from "./home.dto.js";
 import { getShortsbyCategory, getAllCategory, getUserCategoriesById,getFollowersFeeds, getRecommendedShorts} from "./home.dao.js";
 import { getCategoryIdByName } from "../book/book.dao.js";
+import * as dao from "../users/users.dao.js";
 
 // 카테고리별 쇼츠 리스트 조회 로직
 export const ShortsByCategory = async (category_name, user_id, offset, limit) => {
@@ -11,8 +12,11 @@ export const ShortsByCategory = async (category_name, user_id, offset, limit) =>
     const categoryShorts = await getShortsbyCategory(category_id, user_id, offset, limit);
     const categoryShortsDTOList = [];
 
+
+
     for (const shorts of categoryShorts) {
-        let result = categoryShortsResponseDTO(shorts);
+        let isRecentPost = await dao.hasRecentPostForUser(shorts.user_id);
+        let result = categoryShortsResponseDTO(shorts, isRecentPost);
         categoryShortsDTOList.push(result);
     }
 

--- a/src/home/home.service.js
+++ b/src/home/home.service.js
@@ -5,11 +5,10 @@ import { getShortsbyCategory, getAllCategory, getUserCategoriesById,getFollowers
 import { getCategoryIdByName } from "../book/book.dao.js";
 
 // 카테고리별 쇼츠 리스트 조회 로직
-export const ShortsByCategory = async (category_name, offset, limit) => {
+export const ShortsByCategory = async (category_name, user_id, offset, limit) => {
 
     const category_id = await getCategoryIdByName(category_name);
-
-    const categoryShorts = await getShortsbyCategory(category_id, offset, limit);
+    const categoryShorts = await getShortsbyCategory(category_id, user_id, offset, limit);
     const categoryShortsDTOList = [];
 
     for (const shorts of categoryShorts) {

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -20,6 +20,7 @@ WITH RankedShorts AS (
              s.shorts_id, s.book_id, s.image_url,
              s.phrase, s.title, s.content, s.tag, s.created_at
     HAVING likeCnt >= 20
+    ORDER BY RAND()
     LIMIT ?
 ),
 
@@ -39,6 +40,7 @@ UnrankedShorts AS (
     JOIN SHORTS s ON u.user_id = s.user_id
     JOIN BOOK b ON s.book_id = b.book_id
     WHERE b.category_id = ? AND s.shorts_id NOT IN (SELECT shorts_id FROM RankedShorts)
+    ORDER BY RAND()
     LIMIT ?
 )
 

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -1,5 +1,6 @@
 export const getShortsByCategory = 
-`WITH FilteredShorts AS (
+`
+WITH RankedShorts AS (
     SELECT u.user_id, u.image_url AS profileImg, u.nickname,
            s.shorts_id, s.book_id, s.image_url AS shortsImg,
            s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
@@ -18,40 +19,35 @@ export const getShortsByCategory =
     GROUP BY u.user_id, u.image_url, u.nickname,
              s.shorts_id, s.book_id, s.image_url,
              s.phrase, s.title, s.content, s.tag, s.created_at
-    HAVING likeCnt >= 2
+    HAVING likeCnt >= 20
+    LIMIT ?
 ),
-RankedShorts AS (
-    SELECT user_id, profileImg, nickname, shorts_id, book_id, shortsImg,
-           phrase, phrase_x, phrase_y, title, content, tags, likeCnt, commentCnt, created_at,
-           isLike,
-           ROW_NUMBER() OVER (ORDER BY RAND()) AS RN
-    FROM FilteredShorts
+
+UnrankedShorts AS (
+    SELECT u.user_id, u.image_url AS profileImg, u.nickname,
+           s.shorts_id, s.book_id, s.image_url AS shortsImg,
+           s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
+           (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
+           (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
+           s.created_at,
+           EXISTS (
+               SELECT 1 
+               FROM LIKE_SHORTS ls 
+               WHERE ls.shorts_id = s.shorts_id AND ls.user_id = ?
+           ) AS isLike
+    FROM USERS u
+    JOIN SHORTS s ON u.user_id = s.user_id
+    JOIN BOOK b ON s.book_id = b.book_id
+    WHERE b.category_id = ? AND s.shorts_id NOT IN (SELECT shorts_id FROM RankedShorts)
+    LIMIT ?
 )
-SELECT user_id, profileImg, nickname, shorts_id, book_id, shortsImg,
-       phrase, phrase_x, phrase_y, title, content, tags, likeCnt, commentCnt, created_at,
-       isLike
-FROM RankedShorts
-WHERE RN <= 20
 
-UNION ALL
-
-SELECT u.user_id, u.image_url AS profileImg, u.nickname,
-       s.shorts_id, s.book_id, s.image_url AS shortsImg,
-       s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
-       (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
-       (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
-       s.created_at,
-       EXISTS (
-           SELECT 1 
-           FROM LIKE_SHORTS ls 
-           WHERE ls.shorts_id = s.shorts_id AND ls.user_id = ?
-       ) AS isLike
-FROM USERS u
-JOIN SHORTS s ON u.user_id = s.user_id
-JOIN BOOK b ON s.book_id = b.book_id
-WHERE b.category_id = ? AND s.shorts_id NOT IN (SELECT shorts_id FROM RankedShorts)
-ORDER BY RAND()
-LIMIT 20;
+SELECT * FROM (
+    SELECT * FROM RankedShorts
+    UNION ALL
+    SELECT * FROM UnrankedShorts
+) AS CombinedResults
+ORDER BY RAND();
 `;
 
 export const getUserCategories =

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -3,7 +3,7 @@ export const getShortsByCategory =
 WITH RankedShorts AS (
     SELECT u.user_id, u.image_url AS profileImg, u.account,
            s.shorts_id, s.book_id, s.image_url AS shortsImg,
-           s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
+           s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag,
            (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
            (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
            s.created_at,
@@ -26,7 +26,7 @@ WITH RankedShorts AS (
 UnrankedShorts AS (
     SELECT u.user_id, u.image_url AS profileImg, u.account,
            s.shorts_id, s.book_id, s.image_url AS shortsImg,
-           s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
+           s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag,
            (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
            (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
            s.created_at,

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -5,7 +5,12 @@ export const getShortsByCategory =
            s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
            (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
            (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
-           s.created_at
+           s.created_at,
+           EXISTS (
+               SELECT 1 
+               FROM LIKE_SHORTS ls 
+               WHERE ls.shorts_id = s.shorts_id AND ls.user_id = ?
+           ) AS isLike
     FROM USERS u
     JOIN SHORTS s ON u.user_id = s.user_id
     JOIN BOOK b ON s.book_id = b.book_id
@@ -18,11 +23,13 @@ export const getShortsByCategory =
 RankedShorts AS (
     SELECT user_id, profileImg, nickname, shorts_id, book_id, shortsImg,
            phrase, phrase_x, phrase_y, title, content, tags, likeCnt, commentCnt, created_at,
+           isLike,
            ROW_NUMBER() OVER (ORDER BY RAND()) AS RN
     FROM FilteredShorts
 )
 SELECT user_id, profileImg, nickname, shorts_id, book_id, shortsImg,
-       phrase, phrase_x, phrase_y, title, content, tags, likeCnt, commentCnt, created_at
+       phrase, phrase_x, phrase_y, title, content, tags, likeCnt, commentCnt, created_at,
+       isLike
 FROM RankedShorts
 WHERE RN <= 20
 
@@ -33,7 +40,12 @@ SELECT u.user_id, u.image_url AS profileImg, u.nickname,
        s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
        (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
        (SELECT COUNT(*) FROM COMMENT c WHERE c.shorts_id = s.shorts_id) AS commentCnt,
-       s.created_at
+       s.created_at,
+       EXISTS (
+           SELECT 1 
+           FROM LIKE_SHORTS ls 
+           WHERE ls.shorts_id = s.shorts_id AND ls.user_id = ?
+       ) AS isLike
 FROM USERS u
 JOIN SHORTS s ON u.user_id = s.user_id
 JOIN BOOK b ON s.book_id = b.book_id

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -1,7 +1,7 @@
 export const getShortsByCategory = 
 `
 WITH RankedShorts AS (
-    SELECT u.user_id, u.image_url AS profileImg, u.nickname,
+    SELECT u.user_id, u.image_url AS profileImg, u.account,
            s.shorts_id, s.book_id, s.image_url AS shortsImg,
            s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
            (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,
@@ -16,7 +16,7 @@ WITH RankedShorts AS (
     JOIN SHORTS s ON u.user_id = s.user_id
     JOIN BOOK b ON s.book_id = b.book_id
     WHERE b.category_id = ?
-    GROUP BY u.user_id, u.image_url, u.nickname,
+    GROUP BY u.user_id, u.image_url, u.account,
              s.shorts_id, s.book_id, s.image_url,
              s.phrase, s.title, s.content, s.tag, s.created_at
     HAVING likeCnt >= 20
@@ -24,7 +24,7 @@ WITH RankedShorts AS (
 ),
 
 UnrankedShorts AS (
-    SELECT u.user_id, u.image_url AS profileImg, u.nickname,
+    SELECT u.user_id, u.image_url AS profileImg, u.account,
            s.shorts_id, s.book_id, s.image_url AS shortsImg,
            s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag AS tags,
            (SELECT COUNT(*) FROM LIKE_SHORTS ls WHERE ls.shorts_id = s.shorts_id) AS likeCnt,


### PR DESCRIPTION
## #⃣ 연관된 이슈

- close #140 

## 📝 작업 내용

- 원래 코드에서는 메인화면 카테고리 탭 조회 기능에서 유저인가 로직이 아예 빠져있었습니다.
- 따라서 로그인되었을 때도, 회원이 좋아요를 누른 쇼츠에서 isLike 값이 다 false로 뜨고 있었습니다.
- 관련 쿼리문과 로직을 수정해서 기능이 정상적으로 작동하도록 하였습니다.


➕  카테고리 탭 조회 쿼리문 수정
- 인기쇼츠 30개, 비인기쇼츠 20개 각각 뽑아와서 랜덤으로 정렬하도록 쿼리문 수정하였습니다. (각 개수는 변수값으로 조정 가능)


### 📸 스크린샷 (선택)
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/58ec2d9a-41a4-4934-aacc-d0075ab4728f">




