### PR TITLE
🐛[!HOTFIX] #156: 메인화면 피드에서 유저 정보 반환 수정

### DIFF
--- a/src/home/home.dto.js
+++ b/src/home/home.dto.js
@@ -34,9 +34,9 @@ export const HomeInfoResponseDTO = (user_id, categories, shorts, feeds) => {
             "category": shorts.category
         })) : [],
         "feeds": feeds ? feeds.map(feeds => ({
-            "user_id": feeds.user_id,
+            "userId": feeds.user_id,
+            "account": feeds.account,
             "profileImg": feeds.profileImg,
-            "account": shorts.account,
             "shorts_id": feeds.shorts_id,
             "shortsImg": feeds.shortsImg,
             "phrase": feeds.phrase,

--- a/src/home/home.sql.js
+++ b/src/home/home.sql.js
@@ -108,7 +108,7 @@ export const getFollowerFeed =
 `
 SELECT 
     u.user_id, u.image_url AS profileImg, 
-    u.nickname, s.shorts_id, s.image_url AS shortsImg, 
+    u.account, s.shorts_id, s.image_url AS shortsImg, 
     s.phrase, s.phrase_x, s.phrase_y, s.title, s.content, s.tag, 
     COUNT(ls.like_shorts_id) AS likeCnt, 
     COUNT(c.comment_id) AS commentCnt, 


### PR DESCRIPTION

## #⃣ 연관된 이슈

- close #156 

## 📝 작업 내용

- 피드에서 유저 account, user_id, 프로필사진 반환하도록 수정

### 📸 스크린샷 (선택)

