### PR TITLE
🐛 [!HOTFIX] #161: 모임 상세, 나의 모임 상세 조회 시에 태그값에 # 붙여서 응답 보내기

### DIFF
--- a/src/communities/communities.dto.js
+++ b/src/communities/communities.dto.js
@@ -8,7 +8,7 @@ export const communitiesInfoDTO = (community) => {
         "bookTitle": community.title,   
         "Participants" : community.currentCount,
         "capacity" : community.capacity,
-        "tags": community.tag ? community.tag.split("|") : [],
+        "tags": community.tag ? community.tag.split("|").map(tag => `#${tag}`) : [],
         "location" : community.location,
         "community_id" : community.community_id
     }
@@ -21,7 +21,7 @@ export const mycommunitiesInfoDTO = (community) => {
         "bookTitle": community.title,   
         "Participants" : community.currentCount,
         "capacity" : community.capacity,
-        "tags": community.tag ? community.tag.split("|") : [],
+        "tags": community.tag ? community.tag.split("|").map(tag => `#${tag}`) : [],
         "location" : community.location,
         "unReadCount" : community.unreadCnt,
         "community_id" : community.community_id


### PR DESCRIPTION
## 📝 작업 내용

> DTO를 수정해서, 태그를 구분자로 끊고 #을 붙여 배열로 리턴해주도록 수정하였습니다.

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/15cd5ee7-aabe-4e12-9821-34d26ffccdd6)


## 💬 리뷰 요구사항(선택)
